### PR TITLE
chore: use environment variable to specify Hugo version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.117.0'
+          hugo-version: ${{ env.HUGO_VERSION }}
           extended: true
       - name: Build with Hugo
         env:


### PR DESCRIPTION
## What's this PR related to?

GitHub action responsible for building and deploying the demo site to GitHub Pages.

## What does this PR do?

It modifies the Setup Hugo step (which uses peaceiris/actions-hugo), to use the environment variable `HUGO_VERSION` for specifying `hugo-version`.

## Benefit

In future, you have to update Hugo version only in one place (in `pages.yml`) i.e. environment variable `HUGO_VERSION`.

## Links to relevant documentation

https://docs.github.com/en/actions/learn-github-actions/variables#using-contexts-to-access-variable-values