### PR TITLE
fix: card link

### DIFF
--- a/exampleSite/content/docs/guide/markdown.md
+++ b/exampleSite/content/docs/guide/markdown.md
@@ -46,7 +46,7 @@ Tables aren't part of the core Markdown spec, but Hugo supports them out-of-the-
 ### Code Blocks
 
 {{< cards >}}
-    {{< card link="syntax-highlighting" title="Syntax Highlighting" icon="sparkles" >}}
+    {{< card link="/docs/guide/syntax-highlighting" title="Syntax Highlighting" icon="sparkles" >}}
 {{< /cards >}}
 
 ### Lists


### PR DESCRIPTION
The existing card for Syntax Highlighting leads to a 404 page, I have replaced it with appropriate link

Closes https://github.com/imfing/hextra/issues/4.