### PR TITLE
Line Break Needed Between Steps Shortcode and First Heading

### DIFF
--- a/exampleSite/content/docs/guide/shortcodes/steps.md
+++ b/exampleSite/content/docs/guide/shortcodes/steps.md
@@ -28,7 +28,7 @@ This is the third step.
 Put Markdown h3 header within `steps` shortcode.
 
 ```
-{{% steps %}}
+{{%/* steps */%}}
 
 ### Step 1
 

--- a/exampleSite/content/docs/guide/shortcodes/steps.md
+++ b/exampleSite/content/docs/guide/shortcodes/steps.md
@@ -38,5 +38,5 @@ This is the first step.
 
 This is the second step.
 
-{{% /steps %}}
+{{%/* /steps */%}}
 ```

--- a/exampleSite/content/docs/guide/shortcodes/steps.md
+++ b/exampleSite/content/docs/guide/shortcodes/steps.md
@@ -28,7 +28,8 @@ This is the third step.
 Put Markdown h3 header within `steps` shortcode.
 
 ```
-{{%/* steps */%}}
+{{% steps %}}
+
 ### Step 1
 
 This is the first step.
@@ -36,5 +37,6 @@ This is the first step.
 ### Step 2
 
 This is the second step.
-{{%/* /steps */%}}
+
+{{% /steps %}}
 ```


### PR DESCRIPTION
There needs to be a line break between `{{% steps %}}` and the first H3

If there is no line break between {{% steps %}}  and the first heading, the content is not rendered correctly - example:

<img width="417" alt="Screenshot 2023-09-04 at 11 24 47 PM" src="https://github.com/imfing/hextra/assets/52619598/510c455d-e77a-47cc-8c9f-7ece9f218ae2">
