### PR TITLE
fix: htmlUnescape page description

### DIFF
--- a/layouts/partials/utils/page-description.html
+++ b/layouts/partials/utils/page-description.html
@@ -1,11 +1,11 @@
-{{ with .Description | plainify -}}
+{{ with .Description | plainify | htmlUnescape -}}
   {{ . -}}
 {{ else -}}
   {{ if .IsHome -}}
-    {{ with .Site.Params.description | plainify -}}
+    {{ with .Site.Params.description | plainify | htmlUnescape -}}
       {{ . -}}
     {{ end -}}
   {{ else -}}
-    {{ .Summary | plainify | chomp -}}
+    {{ .Summary | plainify | htmlUnescape | chomp -}}
   {{ end -}}
 {{ end -}}


### PR DESCRIPTION
If contents has escape word(like >), description in blog list page show escape for html (like &gt;).
This often occurs on pages that contain source code.

so, add "htmlUnescape" funtion in page-description.html.

