### PR TITLE
feat: enhance image resolving

### DIFF
--- a/exampleSite/content/docs/guide/organize-files.md
+++ b/exampleSite/content/docs/guide/organize-files.md
@@ -80,11 +80,11 @@ For example, add an image file `image.png` alongside the `my-page.md` file:
 
 Then, we can use the following Markdown syntax to add the image to the content:
 
-```markdown
+```markdown {filename="content/docs/my-page.md"}
 ![](image.png)
 ```
 
-We can also utilize the [page bundles][page-bundles] feature of Hugo to organize the image files together with the Markdown file. To achieve that, turn the `my-page.md` file into a directory `my-page` and put the content into a file named `index.md`:
+We can also utilize the [page bundles][page-bundles] feature of Hugo to organize the image files together with the Markdown file. To achieve that, turn the `my-page.md` file into a directory `my-page` and put the content into a file named `index.md`, and put the image files inside the `my-page` directory:
 
 {{< filetree/container >}}
   {{< filetree/folder name="content" >}}
@@ -97,7 +97,7 @@ We can also utilize the [page bundles][page-bundles] feature of Hugo to organize
   {{< /filetree/folder >}}
 {{< /filetree/container >}}
 
-```markdown
+```markdown {filename="content/docs/my-page/index.md"}
 ![](image.png)
 ```
 
@@ -116,7 +116,9 @@ Alternatively, we can also put the image files in the `static` directory, which 
   {{< /filetree/folder >}}
 {{< /filetree/container >}}
 
-```markdown
+Note that the image path begins with a slash `/` and is relative to the static directory:
+
+```markdown {filename="content/docs/my-page.md"}
 ![](/images/image.png)
 ```
 

--- a/exampleSite/content/docs/guide/organize-files.md
+++ b/exampleSite/content/docs/guide/organize-files.md
@@ -81,7 +81,7 @@ For example, add an image file `image.png` alongside the `my-page.md` file:
 Then, we can use the following Markdown syntax to add the image to the content:
 
 ```markdown
-![Image Alt Text](image.png)
+![](image.png)
 ```
 
 We can also utilize the [page bundles][page-bundles] feature of Hugo to organize the image files together with the Markdown file. To achieve that, turn the `my-page.md` file into a directory `my-page` and put the content into a file named `index.md`:
@@ -98,7 +98,7 @@ We can also utilize the [page bundles][page-bundles] feature of Hugo to organize
 {{< /filetree/container >}}
 
 ```markdown
-![Image Alt Text](image.png)
+![](image.png)
 ```
 
 Alternatively, we can also put the image files in the `static` directory, which will make the images available for all pages:
@@ -117,7 +117,7 @@ Alternatively, we can also put the image files in the `static` directory, which 
 {{< /filetree/container >}}
 
 ```markdown
-![Image Alt Text](/images/image.png)
+![](/images/image.png)
 ```
 
 [page-bundles]: https://gohugo.io/content-management/page-bundles/#leaf-bundles

--- a/exampleSite/content/docs/guide/organize-files.md
+++ b/exampleSite/content/docs/guide/organize-files.md
@@ -63,3 +63,61 @@ weight: 2
 ## Configure Content Directory
 
 If we need to use a different directory for our content, we can do so by setting the [`contentDir`](https://gohugo.io/getting-started/configuration/#contentdir) parameter in our site configuration file.
+
+## Add Images
+
+To add images, the easiest way is to put the image files in the same directory as the Markdown file.
+For example, add an image file `image.png` alongside the `my-page.md` file:
+
+{{< filetree/container >}}
+  {{< filetree/folder name="content" >}}
+    {{< filetree/folder name="docs" >}}
+        {{< filetree/file name="my-page.md" >}}
+        {{< filetree/file name="image.png" >}}
+    {{< /filetree/folder >}}
+  {{< /filetree/folder >}}
+{{< /filetree/container >}}
+
+Then, we can use the following Markdown syntax to add the image to the content:
+
+```markdown
+![Image Alt Text](image.png)
+```
+
+We can also utilize the [page bundles][page-bundles] feature of Hugo to organize the image files together with the Markdown file. To achieve that, turn the `my-page.md` file into a directory `my-page` and put the content into a file named `index.md`:
+
+{{< filetree/container >}}
+  {{< filetree/folder name="content" >}}
+    {{< filetree/folder name="docs" >}}
+        {{< filetree/folder name="my-page" >}}
+            {{< filetree/file name="index.md" >}}
+            {{< filetree/file name="image.png" >}}
+        {{< /filetree/folder >}}
+    {{< /filetree/folder >}}
+  {{< /filetree/folder >}}
+{{< /filetree/container >}}
+
+```markdown
+![Image Alt Text](image.png)
+```
+
+Alternatively, we can also put the image files in the `static` directory, which will make the images available for all pages:
+
+{{< filetree/container >}}
+  {{< filetree/folder name="static" >}}
+    {{< filetree/folder name="images" >}}
+        {{< filetree/file name="image.png" >}}
+    {{< /filetree/folder >}}
+  {{< /filetree/folder >}}
+  {{< filetree/folder name="content" >}}
+    {{< filetree/folder name="docs" >}}
+        {{< filetree/file name="my-page.md" >}}
+    {{< /filetree/folder >}}
+  {{< /filetree/folder >}}
+{{< /filetree/container >}}
+
+```markdown
+![Image Alt Text](/images/image.png)
+```
+
+[page-bundles]: https://gohugo.io/content-management/page-bundles/#leaf-bundles

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,8 +1,26 @@
-{{- if .Title -}}
+{{- $alt := .PlainText | safeHTML -}}
+{{- $lazyLoading := .Page.Site.Params.enableImagelazyLoading | default true -}}
+{{- $dest := .Destination -}}
+
+{{- $isRemote := not (urls.Parse $dest).Scheme -}}
+{{- $startsWithSlash := hasPrefix $dest "/" -}}
+{{- $isPage := and (eq .Page.Kind "page") (not .Page.BundleType) -}}
+
+{{- if and $dest $isRemote -}}
+  {{- if $startsWithSlash -}}
+    {{/* Images under static directory */}}
+    {{- $dest = (relURL $dest) -}}
+  {{- else if $isPage -}}
+    {{/* Images that are sibling to the individual page file */}}
+    {{ $dest = (printf "../%s" $dest) }}
+  {{- end -}}
+{{- end -}}
+
+{{- with .Title -}}
   <figure>
-    <img src="{{ .Destination | safeURL }}" title="{{ .Title }}" alt="{{ .PlainText | safeHTML }}" loading="lazy" />
-    <figcaption>{{ .Title }}</figcaption>
+    <img src="{{ $dest | safeURL }}" title="{{ . }}" alt="{{ $alt }}" {{ if $lazyLoading }}loading="lazy"{{ end }} />
+    <figcaption>{{ . }}</figcaption>
   </figure>
 {{- else -}}
-  <img src="{{ .Destination | safeURL }}" alt="{{ .PlainText | safeHTML }}" loading="lazy" />
+  <img src="{{ $dest | safeURL }}" alt="{{ $alt }}" {{ if $lazyLoading }}loading="lazy"{{ end }} />
 {{- end -}}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -3,14 +3,15 @@
 {{- $dest := .Destination -}}
 
 {{- $isRemote := not (urls.Parse $dest).Scheme -}}
-{{- $startsWithSlash := hasPrefix $dest "/" -}}
 {{- $isPage := and (eq .Page.Kind "page") (not .Page.BundleType) -}}
+{{- $startsWithSlash := hasPrefix $dest "/" -}}
+{{- $startsWithRelative := hasPrefix $dest "../" -}}
 
 {{- if and $dest $isRemote -}}
   {{- if $startsWithSlash -}}
     {{/* Images under static directory */}}
     {{- $dest = (relURL $dest) -}}
-  {{- else if $isPage -}}
+  {{- else if and $isPage (not $startsWithRelative) -}}
     {{/* Images that are sibling to the individual page file */}}
     {{ $dest = (printf "../%s" $dest) }}
   {{- end -}}


### PR DESCRIPTION
* add support for resolving relative sibling images

this would enhance the case in #74 

consider the following structure, `image1.jpg` and `image2.jpg` can only be accessed in `_index.md`

```
content/
├── docs
│   ├── my-page
│   │   ├── content1.md
│   │   ├── content2.md
│   │   ├── image1.jpg
│   │   ├── image2.png
│   │   └── _index.md
```

with this PR, `content1.md` and content2.md` will also be able to reference these images like normal: `![](image1.jpg)`

which will eventually be rendered using relative path `../image1.jpg`