### PR TITLE
fix: add integrity attribute to styles css preload tag

### DIFF
--- a/layouts/partials/head-css.html
+++ b/layouts/partials/head-css.html
@@ -7,7 +7,7 @@
 
   {{- if hugo.IsProduction }}
     {{- $styles = $styles | minify | fingerprint }}
-    <link rel="preload" href="{{ $styles.RelPermalink }}" as="style" />
+    <link rel="preload" href="{{ $styles.RelPermalink }}" as="style" integrity="{{ $styles.Data.Integrity }}" />
     <link href="{{ $styles.RelPermalink }}" rel="stylesheet" integrity="{{ $styles.Data.Integrity }}" />
   {{- else }}
     <link href="{{ $styles.RelPermalink }}" rel="stylesheet" />


### PR DESCRIPTION
resolve the issue that the browser console complaining about:

```
A preload for 'https://imfing.github.io/hextra/css/compiled/main.min.bc3a9825af59dee550443f0f12871782ccd79449c748f4fc15fee05ce440c174.css' is found, but is not used due to an integrity mismatch.
```