### PR TITLE
fix: reverse order in blog list page

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -6,11 +6,7 @@
         <br class="mt-1.5 text-sm" />
         <h1 class="text-center mt-2 text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">{{ .Title }}</h1>
         <div class="content">{{ .Content }}</div>
-        {{ $pages := .Pages.ByDate }}
-        {{- if eq .Site.Params.blog.order "desc" }}
-          {{ $pages = $pages.Reverse }}
-        {{ end -}}
-        {{ range $pages }}
+        {{ range .Pages.ByDate.Reverse }}
           <div class="mb-10">
             <h3><a style="color: inherit; text-decoration: none;" class="block font-semibold mt-8 text-2xl " href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
             <p class="opacity-80 mt-6 leading-7">

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -6,7 +6,11 @@
         <br class="mt-1.5 text-sm" />
         <h1 class="text-center mt-2 text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">{{ .Title }}</h1>
         <div class="content">{{ .Content }}</div>
-        {{ range .Pages.ByDate }}
+        {{ $pages := .Pages.ByDate }}
+        {{- if eq .Site.Params.blog.order "desc" }}
+          {{ $pages = $pages.Reverse }}
+        {{ end -}}
+        {{ range $pages }}
           <div class="mb-10">
             <h3><a style="color: inherit; text-decoration: none;" class="block font-semibold mt-8 text-2xl " href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
             <p class="opacity-80 mt-6 leading-7">


### PR DESCRIPTION
Most users will want to list the most recent posts on their blog.

so, support reverse order using param `params.blog.order: desc`