### PR TITLE
fix: search shortcut based on user platform

### DIFF
--- a/assets/js/flexsearch.js
+++ b/assets/js/flexsearch.js
@@ -1,5 +1,16 @@
 // Search functionality using FlexSearch.
 
+// Change shortcut key to cmd+k on Mac.
+document.addEventListener("DOMContentLoaded", function () {
+  if (navigator.userAgent.includes('Macintosh')) {
+    // select the kbd element under the .search-wrapper class
+    const keys = document.querySelectorAll(".search-wrapper kbd");
+    keys.forEach(key => {
+      key.innerHTML = '<span class="text-xs">⌘</span>K';
+    });
+  }
+});
+
 // Render the search data as JSON.
 // {{ $searchDataFile := printf "%s.search-data.json" .Language.Lang }}
 // {{ $searchData := resources.Get "json/search-data.json" | resources.ExecuteAsTemplate $searchDataFile . }}

--- a/assets/js/flexsearch.js
+++ b/assets/js/flexsearch.js
@@ -1,8 +1,8 @@
 // Search functionality using FlexSearch.
 
-// Change shortcut key to cmd+k on Mac.
+// Change shortcut key to cmd+k on Mac, iPad or iPhone.
 document.addEventListener("DOMContentLoaded", function () {
-  if (navigator.userAgent.includes('Macintosh')) {
+  if (/iPad|iPhone|Macintosh/.test(navigator.userAgent)) {
     // select the kbd element under the .search-wrapper class
     const keys = document.querySelectorAll(".search-wrapper kbd");
     keys.forEach(key => {

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -13,7 +13,7 @@
     <kbd
       class="absolute my-1.5 select-none ltr:right-1.5 rtl:left-1.5 h-5 rounded bg-white px-1.5 font-mono text-[10px] font-medium text-gray-500 border dark:border-gray-100/20 dark:bg-dark/50 contrast-more:border-current contrast-more:text-current contrast-more:dark:border-current items-center gap-1 transition-opacity pointer-events-none hidden sm:flex"
     >
-      <span class="text-xs">⌘</span>K
+      CTRL K
     </kbd>
   </div>
 


### PR DESCRIPTION
fixes #91 

* default to `CTRL K`
* switch to `⌘ K` for macOS/iOS dynamically