### PR TITLE
fix: use div for copyright container in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -24,7 +24,7 @@
   >
     <div class="flex w-full flex-col items-center sm:items-start">
       {{- if (.Site.Params.footer.displayPoweredBy | default true) }}<div class="font-semibold">{{ template "theme-credit" . }}</div>{{ end }}
-      {{- if .Site.Params.footer.displayCopyright }}<p class="mt-6 text-xs">{{ $copyright | markdownify }}</p>{{ end }}
+      {{- if .Site.Params.footer.displayCopyright }}<div class="mt-6 text-xs">{{ $copyright | markdownify }}</div>{{ end }}
     </div>
   </div>
 </footer>


### PR DESCRIPTION
use `<p>` may run into issue when the copyright text contains multiline markdown