### PR TITLE
Add docs for using Hextra as Git submodule, refactor docs for using Hextra as Hugo module

### DIFF
--- a/exampleSite/content/docs/getting-started.md
+++ b/exampleSite/content/docs/getting-started.md
@@ -74,7 +74,7 @@ $ hugo mod init github.com/username/my-site
 $ hugo mod get github.com/imfing/hextra
 ```
 
-Configure your `hugo.yaml` file to use Hextra theme by including the following:
+Configure `hugo.yaml` to use Hextra theme by adding the following:
 
 ```yaml
 module:
@@ -145,7 +145,7 @@ $ hugo new site my-site --format=yaml
 git submodule add https://github.com/imfing/hextra.git themes/hextra
 ```
 
-Configure your `hugo.yaml` file to use Hextra theme by including the following:
+Configure `hugo.yaml` to use Hextra theme by adding the following:
 
 ```yaml
 theme: hextra
@@ -170,15 +170,15 @@ Voila! You can see your new site at `http://localhost:1313/`.
 
 {{% /steps %}}
 
-{{< callout type="info" >}}
-  When using [CI/CD](https://en.wikipedia.org/wiki/CI/CD) for Hugo website deployment, it's essential to ensure that the following command is executed before running the `hugo` command.
 
-  ```shell
-  git submodule update --init
-  ```
+When using [CI/CD](https://en.wikipedia.org/wiki/CI/CD) for Hugo website deployment, it's essential to ensure that the following command is executed before running the `hugo` command.
 
-  Failure to run this command will result in your theme folder not being populated with the necessary Hextra theme files, leading to a build failure.
-{{< /callout >}}
+```shell
+git submodule update --init
+```
+
+Failure to run this command will result in the theme folder not being populated with Hextra theme files, leading to a build failure.
+
 
 
 {{% details title="How to update theme?" %}}

--- a/exampleSite/content/docs/getting-started.md
+++ b/exampleSite/content/docs/getting-started.md
@@ -19,18 +19,47 @@ We have provided a [GitHub Actions workflow](https://docs.github.com/en/pages/ge
 
 ## Start as New Project
 
-### Prerequisites
+There are several ways to use a Hugo theme, all of which are supported by Hextra.
 
-Before we start, make sure we have [Hugo](https://gohugo.io/) installed.
-Please refer to Hugo's [official installation guide](https://gohugo.io/installation/) for more details.
+1. **Hugo Module (recommended)**: The easiest and recommended way to use Hextra is by incorporating it as a [Hugo Module](https://gohugo.io/hugo-modules/). Hugo modules allow you to include external dependencies, like themes or content, in your Hugo website directly from a specific repository. 
 
-[Hugo modules](https://gohugo.io/hugo-modules/) are the recommended way to manage Hugo themes. To use Hugo modules, we need to install [Git](https://git-scm.com/) and [Go](https://go.dev/).
+    In this method:
+    - theme files are fetched from the Hextra repository by Hugo
+    - theme files are stored in Hugo's module cache folder
+    - theme can be updated by running
+
+      ```shell
+      hugo mod get -u github.com/imfing/hextra
+      ```
+
+2. **Git Submodule**: You can also add Hextra as a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules). Git submodule allows you to include a Git repository in an existing Git repository. 
+
+    In this method:
+    - theme files are fetched from the Hextra repository by Git
+    - theme files are stored in your project's `themes` folder
+    - theme can be updated by running
+
+      ```shell
+      git submodule update --remote
+      ```
+
+### Setup Hextra as Hugo Module
+
+#### Prerequisites
+
+Before starting, you need to have the following softwares installed:
+
+- [Hugo (extended version)](https://gohugo.io/installation/)
+- [Git](https://git-scm.com/)
+- [Go](https://go.dev/)
+
+#### Steps
 
 {{% steps %}}
 
 ### Initialize a new Hugo site
 
-```bash
+```shell
 $ hugo new site my-site --format=yaml
 ```
 
@@ -55,7 +84,7 @@ module:
 
 ### Create your first content pages
 
-Let's create a new content page for the home page and the documentation page:
+Let's create new content page for the home page and the documentation page:
 
 ```shell
 $ hugo new content/_index.md
@@ -73,14 +102,18 @@ Voila! You can see your new site at `http://localhost:1313/`.
 {{% /steps %}}
 
 
-## Update Theme
-
 {{% details title="How to update theme?" %}}
 
-To update the theme to the [latest released version](https://github.com/imfing/hextra/releases), run the following command:
+To update all Hugo modules in your project to their latest versions, run the following command:
 
 ```shell
 $ hugo mod get -u
+```
+
+To update only Hextra to the [latest released version](https://github.com/imfing/hextra/releases), run the following command:
+
+```shell
+hugo mod get -u github.com/imfing/hextra
 ```
 
 See [Hugo Modules](https://gohugo.io/hugo-modules/use-modules/#update-all-modules) for more details.

--- a/exampleSite/content/docs/getting-started.md
+++ b/exampleSite/content/docs/getting-started.md
@@ -19,29 +19,11 @@ We have provided a [GitHub Actions workflow](https://docs.github.com/en/pages/ge
 
 ## Start as New Project
 
-There are several ways to use a Hugo theme, all of which are supported by Hextra.
+There are two main ways to add the Hextra theme to your Hugo project.
 
-1. **Hugo Modules (recommended)**: The easiest and recommended way to use Hextra. [Hugo modules](https://gohugo.io/hugo-modules/) allow you to include external dependencies, like theme or content, in your website directly from a specific repository. 
+1. **Hugo Modules (Recommended)**: The simplest and recommended method. [Hugo modules](https://gohugo.io/hugo-modules/) let you pull in the theme directly from its online source. Theme is downloaded automatically and managed by Hugo.
 
-    In this method:
-    - theme files are fetched from the Hextra repository by Hugo
-    - theme files are stored in Hugo's module cache folder
-    - theme can be updated by running
-
-      ```shell
-      hugo mod get -u github.com/imfing/hextra
-      ```
-
-2. **Git Submodule**: You can also add Hextra as a [Git Submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules). Git submodule allows you to include a Git repository in an existing Git repository.
-
-    In this method:
-    - theme files are fetched from the Hextra repository by Git
-    - theme files are stored in your project's `themes` folder
-    - theme can be updated by running
-
-      ```shell
-      git submodule update --remote
-      ```
+2. **Git Submodule**: Alternatively, add Hextra as a [Git Submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules). The theme will be downloaded by Git and stored in your project's `themes` folder.
 
 ### Setup Hextra as Hugo module
 
@@ -178,7 +160,6 @@ git submodule update --init
 ```
 
 Failure to run this command will result in the theme folder not being populated with Hextra theme files, leading to a build failure.
-
 
 
 {{% details title="How to update theme?" %}}

--- a/exampleSite/content/docs/getting-started.md
+++ b/exampleSite/content/docs/getting-started.md
@@ -21,7 +21,7 @@ We have provided a [GitHub Actions workflow](https://docs.github.com/en/pages/ge
 
 There are several ways to use a Hugo theme, all of which are supported by Hextra.
 
-1. **Hugo module (recommended)**: The easiest and recommended way to use Hextra is by incorporating it as a [Hugo Module](https://gohugo.io/hugo-modules/). Hugo modules allow you to include external dependencies, like themes or content, in your Hugo website directly from a specific repository. 
+1. **Hugo Modules (recommended)**: The easiest and recommended way to use Hextra. [Hugo modules](https://gohugo.io/hugo-modules/) allow you to include external dependencies, like theme or content, in your website directly from a specific repository. 
 
     In this method:
     - theme files are fetched from the Hextra repository by Hugo
@@ -32,7 +32,7 @@ There are several ways to use a Hugo theme, all of which are supported by Hextra
       hugo mod get -u github.com/imfing/hextra
       ```
 
-2. **Git submodule**: You can also add Hextra as a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules). Git submodule allows you to include a Git repository in an existing Git repository. 
+2. **Git Submodule**: You can also add Hextra as a [Git Submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules). Git submodule allows you to include a Git repository in an existing Git repository.
 
     In this method:
     - theme files are fetched from the Hextra repository by Git

--- a/exampleSite/content/docs/getting-started.md
+++ b/exampleSite/content/docs/getting-started.md
@@ -21,7 +21,7 @@ We have provided a [GitHub Actions workflow](https://docs.github.com/en/pages/ge
 
 There are several ways to use a Hugo theme, all of which are supported by Hextra.
 
-1. **Hugo Module (recommended)**: The easiest and recommended way to use Hextra is by incorporating it as a [Hugo Module](https://gohugo.io/hugo-modules/). Hugo modules allow you to include external dependencies, like themes or content, in your Hugo website directly from a specific repository. 
+1. **Hugo module (recommended)**: The easiest and recommended way to use Hextra is by incorporating it as a [Hugo Module](https://gohugo.io/hugo-modules/). Hugo modules allow you to include external dependencies, like themes or content, in your Hugo website directly from a specific repository. 
 
     In this method:
     - theme files are fetched from the Hextra repository by Hugo
@@ -32,7 +32,7 @@ There are several ways to use a Hugo theme, all of which are supported by Hextra
       hugo mod get -u github.com/imfing/hextra
       ```
 
-2. **Git Submodule**: You can also add Hextra as a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules). Git submodule allows you to include a Git repository in an existing Git repository. 
+2. **Git submodule**: You can also add Hextra as a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules). Git submodule allows you to include a Git repository in an existing Git repository. 
 
     In this method:
     - theme files are fetched from the Hextra repository by Git
@@ -43,7 +43,7 @@ There are several ways to use a Hugo theme, all of which are supported by Hextra
       git submodule update --remote
       ```
 
-### Setup Hextra as Hugo Module
+### Setup Hextra as Hugo module
 
 #### Prerequisites
 
@@ -74,7 +74,7 @@ $ hugo mod init github.com/username/my-site
 $ hugo mod get github.com/imfing/hextra
 ```
 
-Edit `hugo.yaml` to enable Hextra theme:
+Configure your `hugo.yaml` file to use Hextra theme by including the following:
 
 ```yaml
 module:
@@ -120,6 +120,84 @@ See [Hugo Modules](https://gohugo.io/hugo-modules/use-modules/#update-all-module
 
 {{% /details %}}
 
+### Setup Hextra as Git submodule
+
+#### Prerequisites
+
+Before starting, you need to have the following softwares installed:
+
+- [Hugo (extended version)](https://gohugo.io/installation/)
+- [Git](https://git-scm.com/)
+
+#### Steps
+
+{{% steps %}}
+
+### Initialize a new Hugo site
+
+```shell
+$ hugo new site my-site --format=yaml
+```
+
+### Add Hextra theme as a Git submodule
+
+```shell
+git submodule add https://github.com/imfing/hextra.git themes/hextra
+```
+
+Configure your `hugo.yaml` file to use Hextra theme by including the following:
+
+```yaml
+theme: hextra
+```
+
+### Create your first content pages
+
+Let's create new content page for the home page and the documentation page:
+
+```shell
+$ hugo new content/_index.md
+$ hugo new content/docs/_index.md
+```
+
+### Preview the site locally
+
+```shell
+$ hugo server --buildDrafts --disableFastRender
+```
+
+Voila! You can see your new site at `http://localhost:1313/`.
+
+{{% /steps %}}
+
+{{< callout type="info" >}}
+  When using [CI/CD](https://en.wikipedia.org/wiki/CI/CD) for Hugo website deployment, it's essential to ensure that the following command is executed before running the `hugo` command.
+
+  ```shell
+  git submodule update --init
+  ```
+
+  Failure to run this command will result in your theme folder not being populated with the necessary Hextra theme files, leading to a build failure.
+{{< /callout >}}
+
+
+{{% details title="How to update theme?" %}}
+
+To update all submodules in your repository to their latest commits, run the following command:
+
+```shell
+$ git submodule update --remote
+```
+
+To update only Hextra to the latest commit, run the following command:
+
+```shell
+git submodule update --remote themes/hextra
+```
+
+See [Git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for more details.
+
+{{% /details %}}
 
 ## Next
 


### PR DESCRIPTION
## Issue with this PR

At present, an info callout (which is part of this PR) appears like this:

![image](https://github.com/imfing/hextra/assets/122173059/d5843dab-1291-4ec1-ac90-47515072090e)

All my attempts to fix this went in vain. I observed that there is a leading empty `<p>` tag and trailing empty `<p>` tag within the markup of the shortcode. By markup I am referring to the HTML rendered by the shortcode.

It appears correctly when I delete these empty tags.

![image](https://github.com/imfing/hextra/assets/122173059/06b3e194-18b0-444e-bc1c-557c94d78887)

Trimming newline characters while processing the Hugo shortcode might be a fix for this.

## Enhancement

I realized that the getting-started page looks quite lengthy when the Git submodule docs is added. This can be a bad user experience especially for beginner/new users of Hextra. For a better user experience, I suggest that we split 'Setup Hextra as Hugo module' section and 'Setup Hextra as Git submodule' section to new files (under getting started).

Then we can link these pages using cards on the getting-started page.

Let me know your thoughts @imfing. I can amend the PR accordingly.


