### PR TITLE
fix: skip scroll event if no backToTop element

### DIFF
--- a/assets/js/back-to-top.js
+++ b/assets/js/back-to-top.js
@@ -1,18 +1,22 @@
-const backToTop = document.querySelector("#backToTop");
+// Back to top button
 
-document.addEventListener("scroll", (event) => {
-  if (window.scrollY > 300) {
-    backToTop.classList.remove("opacity-0");
-  } else {
-    backToTop.classList.add("opacity-0");
+document.addEventListener("DOMContentLoaded", function () {
+  const backToTop = document.querySelector("#backToTop");
+  if (backToTop) {
+    document.addEventListener("scroll", (e) => {
+      if (window.scrollY > 300) {
+        backToTop.classList.remove("opacity-0");
+      } else {
+        backToTop.classList.add("opacity-0");
+      }
+    });
   }
 });
 
-
 function scrollUp() {
   window.scroll({
-    top: 0, 
-    left: 0, 
-    behavior: 'smooth'
+    top: 0,
+    left: 0,
+    behavior: "smooth",
   });
 }


### PR DESCRIPTION
when the scroll to top element is not present, skip listening to the scroll event