### PR TITLE
fix: add missing translation in blog list

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,3 +1,4 @@
+readMore: "Read more →"
 onThisPage: "On this page"
 editThisPage: "Edit this page on GitHub →"
 lastUpdated: "Last updated on"

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+{{- $readMore := (T "readMore") | default "Read more →" -}}
   <div class='mx-auto flex {{ partial "utils/page-width" . }}'>
     {{ partial "sidebar.html" (dict "context" . "disableSidebar" true "displayPlaceholder" true) }}
     <article class="w-full break-words flex min-h-[calc(100vh-var(--navbar-height))] min-w-0 justify-center pb-8 pr-[calc(env(safe-area-inset-right)-1.5rem)]">
@@ -11,7 +12,7 @@
             <h3><a style="color: inherit; text-decoration: none;" class="block font-semibold mt-8 text-2xl " href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
             <p class="opacity-80 mt-6 leading-7">
               {{- partial "utils/page-description" . }}
-              <span class="inline-block"> <a class="text-[color:hsl(var(--primary-hue),100%,50%)] underline underline-offset-2 decoration-from-font" href="{{ .RelPermalink }}">Read more →</a> </span>
+              <span class="inline-block"> <a class="text-[color:hsl(var(--primary-hue),100%,50%)] underline underline-offset-2 decoration-from-font" href="{{ .RelPermalink }}">{{ $readMore }}</a> </span>
             </p>
             <p class="opacity-50 text-sm mt-6 leading-7">{{ partial "utils/format-date" .Date }}</p>
           </div>


### PR DESCRIPTION
In blog list page,
"Read More →" is not a variable that can be translated.