### PR TITLE
fix: broken "edit this page" link in windows

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -26,7 +26,7 @@
       <div class="{{ $borderClass }} sticky bottom-0 flex flex-col items-start gap-2 pb-8 dark:border-neutral-800 contrast-more:border-t contrast-more:border-neutral-400 contrast-more:shadow-none contrast-more:dark:border-neutral-400">
         {{- if site.Params.editURL.enable -}}
           {{- $editURL := site.Params.editURL.base | default "" -}}
-          {{- with .File -}}{{ $editURL = urls.JoinPath $editURL .Path }}{{- end -}}
+          {{- with .File -}}{{ $editURL = urls.JoinPath $editURL (replace .Path "\\" "/") }}{{- end -}}
           {{- with .Params.editURL -}}{{ $editURL = .Params.editURL }}{{- end -}}
           <a class="text-xs font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 contrast-more:text-gray-800 contrast-more:dark:text-gray-50" href="{{ $editURL }}" target="_blank" rel="noreferer">{{ $editThisPage }}</a>
         {{- end -}}


### PR DESCRIPTION
In windows environment, "edit this page" has broken link.
It seems to be broken because the file path separator is different.

linux, mac : https://github.com/test/test/edit/master/a/b/c/index.md
windows : https://github.com/test/test/edit/master/a%5Cb%5Cc%5Cindex.md

so in toc, .File.Path need to be replaced "\\" to "/"