### PR TITLE
feat(search): support different search index types

### DIFF
--- a/assets/json/search-data.json
+++ b/assets/json/search-data.json
@@ -1,7 +1,7 @@
 {{/* FlexSearch Index Data */}}
-{{- $indexType := site.Params.search.flexsearch.index | default "fulltext" -}}
+{{- $indexType := site.Params.search.flexsearch.index | default "content" -}}
 
-{{- if not (in (slice "fulltext" "heading" "title" "summary") $indexType) -}}
+{{- if not (in (slice "content" "summary" "heading" "title" ) $indexType) -}}
   {{- errorf "unknown flexsearch index type: %s" $indexType -}}
 {{- end -}}
 

--- a/assets/json/search-data.json
+++ b/assets/json/search-data.json
@@ -1,3 +1,10 @@
+{{/* FlexSearch Index Data */}}
+{{- $indexType := site.Params.search.flexsearch.index | default "fulltext" -}}
+
+{{- if not (in (slice "fulltext" "heading" "title") $indexType) -}}
+  {{- errorf "unknown flexsearch index type: %s" $indexType -}}
+{{- end -}}
+
 {{- $pages := where .Site.Pages "Kind" "in" (slice "page" "section") -}}
 {{- $pages = where $pages "Params.excludeSearch" "!=" true -}}
 {{- $pages = where $pages "Content" "!=" "" -}}
@@ -7,7 +14,7 @@
 {{- range $index, $page := $pages -}}
   {{- $pageTitle := $page.LinkTitle | default $page.File.BaseFileName -}}
   {{- $pageLink := $page.RelPermalink -}}
-  {{- $data := partial "utils/fragments" $page -}}
+  {{- $data := partial "utils/fragments" (dict "context" $page "type" $indexType) -}}
   {{- $output = $output | merge (dict $pageLink (dict "title" $pageTitle "data" $data)) -}}
 {{- end -}}
 

--- a/assets/json/search-data.json
+++ b/assets/json/search-data.json
@@ -1,7 +1,7 @@
 {{/* FlexSearch Index Data */}}
 {{- $indexType := site.Params.search.flexsearch.index | default "fulltext" -}}
 
-{{- if not (in (slice "fulltext" "heading" "title") $indexType) -}}
+{{- if not (in (slice "fulltext" "heading" "title" "summary") $indexType) -}}
   {{- errorf "unknown flexsearch index type: %s" $indexType -}}
 {{- end -}}
 

--- a/exampleSite/content/docs/guide/configuration.md
+++ b/exampleSite/content/docs/guide/configuration.md
@@ -198,6 +198,37 @@ By default, the page width is set to `normal`.
 
 Similarly, the width of the navbar and footer can be customized by the `params.navbar.width` and `params.footer.width` parameters.
 
+### Search Index
+
+Fulltext search powered by [FlexSearch](https://github.com/nextapps-de/flexsearch) is enabled by default.
+To customize the search index, set the `params.search.flexsearch.index` parameter in the config file:
+
+```yaml {filename="hugo.yaml"}
+params:
+  # Search
+  search:
+    enable: true
+    type: flexsearch
+
+    flexsearch:
+      # index page by: fulltext | summary | heading | title
+      index: fulltext
+```
+
+available options for `flexsearch.index`:
+- `fulltext` - include full content of the page (default)
+- `summary` - include the summary of the page, see [Hugo Content Summaries](https://gohugo.io/content-management/summaries/) for more details
+- `heading` - include level 1 and level 2 headings
+- `title` - only include the page title
+
+To exclude a page from the search index, set the `excludeSearch: true` in the front matter of the page:
+
+```yaml {filename="content/docs/guide/configuration.md"}
+---
+title: Configuration
+excludeSearch: true
+---
+```
 
 ### Google Analytics
 

--- a/exampleSite/content/docs/guide/configuration.md
+++ b/exampleSite/content/docs/guide/configuration.md
@@ -200,7 +200,7 @@ Similarly, the width of the navbar and footer can be customized by the `params.n
 
 ### Search Index
 
-Fulltext search powered by [FlexSearch](https://github.com/nextapps-de/flexsearch) is enabled by default.
+Full-text search powered by [FlexSearch](https://github.com/nextapps-de/flexsearch) is enabled by default.
 To customize the search index, set the `params.search.flexsearch.index` parameter in the config file:
 
 ```yaml {filename="hugo.yaml"}
@@ -211,14 +211,14 @@ params:
     type: flexsearch
 
     flexsearch:
-      # index page by: fulltext | summary | heading | title
-      index: fulltext
+      # index page by: content | summary | heading | title
+      index: content
 ```
 
 available options for `flexsearch.index`:
-- `fulltext` - include full content of the page (default)
-- `summary` - include the summary of the page, see [Hugo Content Summaries](https://gohugo.io/content-management/summaries/) for more details
-- `heading` - include level 1 and level 2 headings
+- `content` - full content of the page (default)
+- `summary` - summary of the page, see [Hugo Content Summaries](https://gohugo.io/content-management/summaries/) for more details
+- `heading` - level 1 and level 2 headings
 - `title` - only include the page title
 
 To exclude a page from the search index, set the `excludeSearch: true` in the front matter of the page:

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -124,9 +124,8 @@ params:
     type: flexsearch
 
     flexsearch:
-      # index page by: fulltext | summary | heading | title
-      # default: fulltext
-      index: fulltext
+      # index page by: content | summary | heading | title
+      index: content
 
   editURL:
     enable: true

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -123,6 +123,10 @@ params:
     enable: true
     type: flexsearch
 
+    flexsearch:
+      # index page by: fulltext | title | heading
+      # default: fulltext
+      index: fulltext
 
   editURL:
     enable: true

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -124,9 +124,9 @@ params:
     type: flexsearch
 
     flexsearch:
-      # index page by: fulltext | title | heading
+      # index page by: fulltext | summary | heading | title
       # default: fulltext
-      index: fulltext
+      index: summary
 
   editURL:
     enable: true

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -126,7 +126,7 @@ params:
     flexsearch:
       # index page by: fulltext | summary | heading | title
       # default: fulltext
-      index: summary
+      index: fulltext
 
   editURL:
     enable: true

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -117,8 +117,12 @@ params:
   displayUpdatedDate: true
   dateFormat: "January 2, 2006"
 
+  # Search
+  # flexsearch is enabled by default
   search:
     enable: true
+    type: flexsearch
+
 
   editURL:
     enable: true

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -13,16 +13,22 @@
 {{- end -}}
 <script defer src="{{ $scripts.RelPermalink }}" integrity="{{ $scripts.Data.Integrity }}"></script>
 
-{{/* FlexSearch */}}
+
+{{/* Search */}}
 {{- if (site.Params.search.enable | default true) -}}
-  {{- $jsSearchScript := printf "%s.search.js" .Language.Lang -}}
-  {{- $jsSearch := resources.Get "js/flexsearch.js" | resources.ExecuteAsTemplate $jsSearchScript . -}}
-  {{- if hugo.IsProduction -}}
-    {{- $jsSearch = $jsSearch | minify | fingerprint -}}
+  {{- $searchType := site.Params.search.type | default "flexsearch" -}}
+  {{- if eq $searchType "flexsearch" -}}
+    {{- $jsSearchScript := printf "%s.search.js" .Language.Lang -}}
+    {{- $jsSearch := resources.Get "js/flexsearch.js" | resources.ExecuteAsTemplate $jsSearchScript . -}}
+    {{- if hugo.IsProduction -}}
+      {{- $jsSearch = $jsSearch | minify | fingerprint -}}
+    {{- end -}}
+    {{- $flexSearchJS := resources.Get "lib/flexsearch/flexsearch.bundle.min.js" | fingerprint -}}
+    <script defer src="{{ $flexSearchJS.RelPermalink }}" integrity="{{ $flexSearchJS.Data.Integrity }}"></script>
+    <script defer src="{{ $jsSearch.RelPermalink }}" integrity="{{ $jsSearch.Data.Integrity }}"></script>
+  {{- else -}}
+    {{- warnf `search type "%s" is not supported` $searchType -}}
   {{- end -}}
-  {{- $flexSearchJS := resources.Get "lib/flexsearch/flexsearch.bundle.min.js" | fingerprint -}}
-  <script defer src="{{ $flexSearchJS.RelPermalink }}" integrity="{{ $flexSearchJS.Data.Integrity }}"></script>
-  <script defer src="{{ $jsSearch.RelPermalink }}" integrity="{{ $jsSearch.Data.Integrity }}"></script>
 {{- end -}}
 
 {{/* Mermaid */}}

--- a/layouts/partials/utils/fragments.html
+++ b/layouts/partials/utils/fragments.html
@@ -1,5 +1,6 @@
 {{/* Split page raw content into fragments */}}
-{{ $page := . }}
+{{ $page := .context }}
+{{ $type := .type | default "fulltext" }}
 
 {{ $headingKeys := slice }}
 {{ $headingTitles := slice }}
@@ -22,24 +23,36 @@
 {{ $len := len $headingKeys }}
 {{ $data := dict }}
 
-{{ if eq $len 0 }}
-  {{ $data = $data | merge (dict "" $page.Plain) }}
-{{ else }}
-  {{ range seq $len }}
-    {{ $i := sub $len . }}
-    {{ $headingKey := index $headingKeys $i }}
-    {{ $headingTitle := index $headingTitles $i }}
+{{ if eq $type "fulltext" }}
+  {{ if eq $len 0 }}
+    {{ $data = $data | merge (dict "" ($page.Plain)) }}
+  {{ else }}
+    {{/* Split the raw content from bottom to top */}}
+    {{ range seq $len }}
+      {{ $i := sub $len . }}
+      {{ $headingKey := index $headingKeys $i }}
+      {{ $headingTitle := index $headingTitles $i }}
 
-    {{ if eq $i 0 }}
-      {{ $data = $data | merge (dict $headingKey ($content | markdownify | plainify)) }}
-    {{ else }}
-      {{ $parts := split $content (printf "\n%s\n" $headingTitle) }}
-      {{ $lastPart := index $parts (sub (len $parts) 1) }}
+      {{ if eq $i 0 }}
+        {{ $data = $data | merge (dict $headingKey ($content | markdownify | plainify | chomp)) }}
+      {{ else }}
+        {{ $parts := split $content (printf "\n%s\n" $headingTitle) }}
+        {{ $lastPart := index $parts (sub (len $parts) 1) }}
 
-      {{ $data = $data | merge (dict $headingKey ($lastPart | markdownify | plainify)) }}
-      {{ $content = strings.TrimSuffix $lastPart $content }}
-      {{ $content = strings.TrimSuffix (printf "\n%s\n" $headingTitle) $content }}
+        {{ $data = $data | merge (dict $headingKey ($lastPart | markdownify | plainify | chomp)) }}
+        {{ $content = strings.TrimSuffix $lastPart $content }}
+        {{ $content = strings.TrimSuffix (printf "\n%s\n" $headingTitle) $content }}
+      {{ end }}
     {{ end }}
   {{ end }}
+{{ else if (eq $type "heading" ) }}
+  {{/* Put heading keys with empty content to the data object */}}
+  {{ range $headingKeys }}
+    {{ $data = $data | merge (dict . "") }}
+  {{ end }}
+{{ else if (eq $type "title") }}
+  {{/* Use empty data object since title is included in search-data.json */}}
+  {{ $data = $data | merge (dict "" "") }}
 {{ end }}
+
 {{ return $data }}

--- a/layouts/partials/utils/fragments.html
+++ b/layouts/partials/utils/fragments.html
@@ -1,6 +1,6 @@
 {{/* Split page raw content into fragments */}}
 {{ $page := .context }}
-{{ $type := .type | default "fulltext" }}
+{{ $type := .type | default "content" }}
 
 {{ $headingKeys := slice }}
 {{ $headingTitles := slice }}
@@ -23,7 +23,8 @@
 {{ $len := len $headingKeys }}
 {{ $data := dict }}
 
-{{ if eq $type "fulltext" }}
+{{ if eq $type "content" }}
+  {{/* Include full content of the page */}}
   {{ if eq $len 0 }}
     {{ $data = $data | merge (dict "" ($page.Plain | htmlUnescape | chomp)) }}
   {{ else }}

--- a/layouts/partials/utils/fragments.html
+++ b/layouts/partials/utils/fragments.html
@@ -25,7 +25,7 @@
 
 {{ if eq $type "fulltext" }}
   {{ if eq $len 0 }}
-    {{ $data = $data | merge (dict "" ($page.Plain)) }}
+    {{ $data = $data | merge (dict "" ($page.Plain | htmlUnescape | chomp)) }}
   {{ else }}
     {{/* Split the raw content from bottom to top */}}
     {{ range seq $len }}
@@ -34,12 +34,12 @@
       {{ $headingTitle := index $headingTitles $i }}
 
       {{ if eq $i 0 }}
-        {{ $data = $data | merge (dict $headingKey ($content | markdownify | plainify | chomp)) }}
+        {{ $data = $data | merge (dict $headingKey ($content | markdownify | plainify | htmlUnescape | chomp)) }}
       {{ else }}
         {{ $parts := split $content (printf "\n%s\n" $headingTitle) }}
         {{ $lastPart := index $parts (sub (len $parts) 1) }}
 
-        {{ $data = $data | merge (dict $headingKey ($lastPart | markdownify | plainify | chomp)) }}
+        {{ $data = $data | merge (dict $headingKey ($lastPart | markdownify | plainify | htmlUnescape | chomp)) }}
         {{ $content = strings.TrimSuffix $lastPart $content }}
         {{ $content = strings.TrimSuffix (printf "\n%s\n" $headingTitle) $content }}
       {{ end }}
@@ -54,7 +54,7 @@
   {{/* Use empty data object since title is included in search-data.json */}}
   {{ $data = $data | merge (dict "" "") }}
 {{ else if (eq $type "summary" ) }}
-  {{ $data = $data | merge (dict "" ($page.Summary | plainify | chomp)) }}
+  {{ $data = $data | merge (dict "" ($page.Summary | plainify | htmlUnescape | chomp)) }}
 {{ end }}
 
 {{ return $data }}

--- a/layouts/partials/utils/fragments.html
+++ b/layouts/partials/utils/fragments.html
@@ -48,6 +48,7 @@
   {{ end }}
 {{ else if (eq $type "heading" ) }}
   {{/* Put heading keys with empty content to the data object */}}
+  {{ $data = dict "" "" }}
   {{ range $headingKeys }}
     {{ $data = $data | merge (dict . "") }}
   {{ end }}

--- a/layouts/partials/utils/fragments.html
+++ b/layouts/partials/utils/fragments.html
@@ -53,6 +53,8 @@
 {{ else if (eq $type "title") }}
   {{/* Use empty data object since title is included in search-data.json */}}
   {{ $data = $data | merge (dict "" "") }}
+{{ else if (eq $type "summary" ) }}
+  {{ $data = $data | merge (dict "" ($page.Summary | plainify | chomp)) }}
 {{ end }}
 
 {{ return $data }}


### PR DESCRIPTION
add support for different search index types: `content | summary | heading | title`

resolves #139 

- [x] add documentation for configuring search index type