### PR TITLE
chore: support `services.googleAnalytics.ID`

### DIFF
--- a/exampleSite/content/docs/guide/configuration.md
+++ b/exampleSite/content/docs/guide/configuration.md
@@ -252,8 +252,10 @@ excludeSearch: true
 
 ### Google Analytics
 
-To enable Google Analytics, set the `googleAnalytics` parameter in the config file:
+To enable [Google Analytics](https://marketingplatform.google.com/about/analytics/), set `services.googleAnalytics.ID` flag in `hugo.yaml`:
 
 ```yaml {filename="hugo.yaml"}
-googleAnalytics: G-XXXXXXXXXX
+services:
+  googleAnalytics:
+    ID: G-MEASUREMENT_ID
 ```

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -7,7 +7,9 @@ enableGitInfo: true
 # enableEmoji: false
 hasCJKLanguage: true
 
-# googleAnalytics: G-XXXXXXXXXX
+# services:
+#   googleAnalytics:
+#     ID: G-MEASUREMENT_ID
 
 outputs:
   home: [HTML]

--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -1,4 +1,10 @@
-{{ with .Site.GoogleAnalytics }}
+{{/* site.GoogleAnalytics is deprecated in Hugo v0.120.0 */}}
+{{/* it will be removed in a future version */}}
+{{- $gtagID := "" -}}
+{{- with site.GoogleAnalytics -}}{{ $gtagID = . }}{{- end -}}
+{{- with site.Config.Services.GoogleAnalytics.ID -}}{{ $gtagID = . }}{{- end -}}
+
+{{- with $gtagID }}
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
   <script>
@@ -10,4 +16,4 @@
 
     gtag("config", "{{ . }}");
   </script>
-{{ end }}
+{{ end -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,9 +25,6 @@
 
 
   <!-- Google Analytics -->
-  {{- with .Site.GoogleAnalytics -}}
-    {{- warnf "The `googleAnalytics` option is deprecated from Hugo v0.120.0, please use `services.googleAnalytics.ID`." -}}
-  {{- end -}}
   {{- if and (eq hugo.Environment "production") (or .Site.GoogleAnalytics .Site.Config.Services.GoogleAnalytics.ID) }}
     <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
     {{ partial "google-analytics.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,7 +25,10 @@
 
 
   <!-- Google Analytics -->
-  {{- if and .Site.GoogleAnalytics (eq hugo.Environment "production") }}
+  {{- with .Site.GoogleAnalytics -}}
+    {{- warnf "The `googleAnalytics` option is deprecated from Hugo v0.120.0, please use `services.googleAnalytics.ID`." -}}
+  {{- end -}}
+  {{- if and (eq hugo.Environment "production") (or .Site.GoogleAnalytics .Site.Config.Services.GoogleAnalytics.ID) }}
     <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
     {{ partial "google-analytics.html" . }}
   {{- end }}


### PR DESCRIPTION
and deprecate `site.googleAnalytics`

resolves #171 