### PR TITLE
chore: improve cards compatibility with steps

### DIFF
--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -79,3 +79,4 @@
     <div class="line-clamp-3 text-sm font-normal text-gray-500 dark:text-gray-400 px-4 mb-4 mt-2">{{- $subtitle | markdownify -}}</div>
   {{- end -}}
 </a>
+{{- /* Strip trailing newline. */ -}}

--- a/layouts/shortcodes/cards.html
+++ b/layouts/shortcodes/cards.html
@@ -1,5 +1,5 @@
 {{ $rows := .Get "rows" | default "3" }}
 
 <div class="hextra-cards mt-4 gap-4 grid not-prose" style="--rows: {{ $rows }};">
-  {{ .Inner }}
+  {{- .Inner -}}
 </div>


### PR DESCRIPTION
for use cases such as:

```
{{% steps %}}

### Step 1

This is the second step.

{{< cards >}}
  {{< card link="../callout" title="Callout" icon="warning" >}}
  {{< card link="/" title="No Icon" >}}
{{< /cards >}}


### Step 2

This is the second step.

### Step 3

This is the third step.

{{% /steps %}}

```

since empty lines will be treated as Markdown thus generating unwanted `<p>` tag that messes up the HTML