### PR TITLE
feat: support separator in sidebar

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -166,6 +166,6 @@
   </a>
 {{- end -}}
 
-{{- define "sidebear-collapsible-button" -}}
+{{- define "sidebar-collapsible-button" -}}
   <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" class="h-[18px] min-w-[18px] rounded-sm p-0.5 hover:bg-gray-800/5 dark:hover:bg-gray-100/5"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" class="origin-center transition-transform rtl:-rotate-180"></path></svg>
 {{- end -}}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -70,15 +70,21 @@
   {{- with $items := union .context.RegularPages .context.Sections -}}
     {{- if eq $level 0 -}}
       {{- range $items.ByWeight }}
-        {{- $active := eq $pageURL .RelPermalink -}}
-        {{- $shouldOpen := or (.Params.sidebar.open) (.IsAncestor $page) $active | default true }}
-        <li class="{{ if $shouldOpen }}open{{ end }}">
-          {{- template "sidebar-item-link" dict "context" . "active" $active "title" .LinkTitle "link" .RelPermalink -}}
-          {{- if and $toc $active -}}
-            {{- template "sidebar-toc" dict "page" . -}}
-          {{- end -}}
-          {{- template "sidebar-tree" dict "context" . "page" $page "pageURL" $pageURL "level" (add $level 1) "toc" $toc -}}
-        </li>
+        {{- if .Params.sidebar.separator -}}
+          <li class="[word-break:break-word] mt-5 mb-2 px-2 py-1.5 text-sm font-semibold text-gray-900 first:mt-0 dark:text-gray-100">
+            <span class="cursor-default">{{ .LinkTitle }}</span>
+          </li>
+        {{- else -}}
+          {{- $active := eq $pageURL .RelPermalink -}}
+          {{- $shouldOpen := or (.Params.sidebar.open) (.IsAncestor $page) $active | default true }}
+          <li class="{{ if $shouldOpen }}open{{ end }}">
+            {{- template "sidebar-item-link" dict "context" . "active" $active "title" .LinkTitle "link" .RelPermalink -}}
+            {{- if and $toc $active -}}
+              {{- template "sidebar-toc" dict "page" . -}}
+            {{- end -}}
+            {{- template "sidebar-tree" dict "context" . "page" $page "pageURL" $pageURL "level" (add $level 1) "toc" $toc -}}
+          </li>
+        {{- end -}}
       {{- end -}}
     {{- else -}}
       <div class="ltr:pr-0 overflow-hidden">
@@ -158,10 +164,6 @@
       {{- end }}
     {{ end -}}
   </a>
-{{- end -}}
-
-{{- define "sidebar-separator" -}}
-  <div class="mt-4 border-t py-4 dark:border-neutral-800 contrast-more:border-neutral-400 dark:contrast-more:border-neutral-400" />
 {{- end -}}
 
 {{- define "sidebear-collapsible-button" -}}


### PR DESCRIPTION
This PR allows pages with `.Params.sidebar.seperator` set to true to act like a separator.

e.g.

```yaml
---
title: Separator-1
weight: 6
sidebar:
  separator: true
_build:
  render: never
excludeSearch: true
---
```

![image](https://github.com/imfing/hextra/assets/5097752/1656db3a-0989-4b9b-9d92-31fc1401b5f9)
