### PR TITLE
feat: allow overriding poweredBy in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -36,9 +36,11 @@
 
 {{- define "theme-credit" -}}
   <a class="flex text-sm items-center gap-1 text-current" target="_blank" rel="noopener noreferrer" title="Hextra GitHub Homepage" href="https://github.com/imfing/hextra">
-    <span
-      >{{ . | safeHTML }}
-      {{- partial "utils/icon.html" (dict "name" "hextra" "attributes" "height=1em class=\"inline-block ml-1 align-text-bottom\"") -}}
+    <span>
+      {{- . | markdownify -}}
+      {{- if strings.Contains . "Hextra" -}}
+        {{- partial "utils/icon.html" (dict "name" "hextra" "attributes" `height=1em class="inline-block ml-1 align-text-bottom"`) -}}
+      {{- end -}}
     </span>
   </a>
 {{- end -}}


### PR DESCRIPTION
With this PR, the `poweredBy` theme line can be completed overridden:

![image](https://github.com/imfing/hextra/assets/5097752/515b9918-485f-4bd8-adef-82c48c220593)

example `i18n/en.yaml`:

```yaml
poweredBy: test overriding *poweredBy* via `en.yaml`
```

Resolves [comment](https://github.com/imfing/hextra/issues/205#issuecomment-1810707970) in #205 