### PR TITLE
feat: add ability to hide posts in blog listing

### DIFF
--- a/exampleSite/content/blog/_index.md
+++ b/exampleSite/content/blog/_index.md
@@ -8,3 +8,5 @@ title: "Blog"
   {{< icon name="rss" attributes="height=14" >}}
 {{< /hextra/hero-badge >}}
 </div>
+
+Checkout the unlisted post, find it here `/blog/hidden`.

--- a/exampleSite/content/blog/hidden.md
+++ b/exampleSite/content/blog/hidden.md
@@ -1,0 +1,16 @@
+---
+title: Hidden blog entry
+date: 2020-01-01
+tags:
+  - Example
+  - Guide
+excludeSearch: true
+hideOnBlog: true
+---
+
+This post is not listed in the blog overview.
+<!--more-->
+
+## Hidden
+
+This post is not shown in the overview page of the blog because is has `hideOnBlog: true` in the front matter.

--- a/exampleSite/content/docs/advanced/_index.md
+++ b/exampleSite/content/docs/advanced/_index.md
@@ -13,4 +13,5 @@ This section covers some advanced topics of the theme.
   {{< card link="multi-language" title="Multi-language" icon="translate" >}}
   {{< card link="customization" title="Customization" icon="pencil" >}}
   {{< card link="comments" title="Comments System" icon="chat-alt" >}}
+  {{< card link="blog" title="Blog on starting page" icon="chat-alt" >}}
 {{< /cards >}}

--- a/exampleSite/content/docs/advanced/blog-as-entrypoint.md
+++ b/exampleSite/content/docs/advanced/blog-as-entrypoint.md
@@ -1,0 +1,56 @@
+---
+title: Blog as entrypoint
+linkTitle: Blog
+---
+
+This is a little tutorial how to use the starting page as a blog.
+
+<!--more-->
+
+## Directory Structure
+
+{{< filetree/container >}}
+  {{< filetree/folder name="content" >}}
+    {{< filetree/file name="_index.md" >}}
+    {{< filetree/file name="post-1.md" >}}
+    {{< filetree/file name="post-2.md" >}}
+    {{< filetree/file name="about.md" >}}
+    {{< filetree/folder name="docs" state="open" >}}
+      {{< filetree/file name="_index.md" >}}
+      {{< filetree/file name="getting-started.md" >}}
+    {{< /filetree/folder >}}
+  {{< /filetree/folder >}}
+{{< /filetree/container >}}
+
+## Make the entrypoint use the blog template
+
+```yaml {filename="content/_index.md"}
+---
+title: My Docs
+cascade:
+  type: blog
+---
+```
+
+But now the starting page will list all entries, including `/about`.
+
+## Ignore pages
+
+```yaml {filename="content/about.md"}
+---
+title: My Docs
+hideOnBlog: true
+---
+```
+
+Now the page is still available at `/about` but is not listed as post on the starting page.
+
+You can hide areas, too.
+
+```yaml {filename="content/docs/_index.md"}
+---
+title: My Docs
+cascade:
+  hideOnBlog: true
+---
+```

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -8,6 +8,7 @@
         <h1 class="text-center mt-2 text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">{{ .Title }}</h1>
         <div class="content">{{ .Content }}</div>
         {{ range .Pages.ByDate.Reverse }}
+          {{- if not .Params.hideOnBlog -}}
           <div class="mb-10">
             <h3><a style="color: inherit; text-decoration: none;" class="block font-semibold mt-8 text-2xl " href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
             {{- if site.Params.blog.list.displayTags -}}
@@ -25,6 +26,7 @@
             </p>
             <p class="opacity-50 text-sm mt-4 leading-7">{{ partial "utils/format-date" .Date }}</p>
           </div>
+          {{- end -}}
         {{ end }}
       </main>
     </article>


### PR DESCRIPTION
I wanted to use the starting page as blog.
But then all entries like "/about" or "/imprint" will show up as posts as they all are in the same folder `content`.

I added a param `hideOnBlog` to the front matter. That parameter will prevent the file from being listed in the blog overview but it is still accessible.