### PR TITLE
chore: add rel="me" attribute to Mastodon navbar icon

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -42,7 +42,8 @@
 
         {{/* Display icon menu item */}}
         {{- if .Params.icon -}}
-          <a class="p-2 text-current" {{ if $external }}target="_blank" rel="noreferer {{ if eq .Params.icon "mastodon" }}me{{ end }}"{{ end }} href="{{ $link }}" title="{{ or (T .Identifier) .Name | safeHTML }}">
+          {{- $rel := cond (eq .Params.icon "mastodon") "noreferer me" "noreferer" }}
+          <a class="p-2 text-current" {{ if $external }}target="_blank" rel="{{ $rel }}"{{ end }} href="{{ $link }}" title="{{ or (T .Identifier) .Name | safeHTML }}">
             {{- partial "utils/icon.html" (dict "name" .Params.icon "attributes" "height=24") -}}
             <span class="sr-only">{{ or (T .Identifier) .Name | safeHTML }}</span>
           </a>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -42,7 +42,7 @@
 
         {{/* Display icon menu item */}}
         {{- if .Params.icon -}}
-          <a class="p-2 text-current" {{ if $external }}target="_blank" rel="noreferer"{{ end }} href="{{ $link }}" title="{{ or (T .Identifier) .Name | safeHTML }}">
+          <a class="p-2 text-current" {{ if $external }}target="_blank" rel="noreferer {{ if eq .Params.icon "mastodon" }}me{{ end }}"{{ end }} href="{{ $link }}" title="{{ or (T .Identifier) .Name | safeHTML }}">
             {{- partial "utils/icon.html" (dict "name" .Params.icon "attributes" "height=24") -}}
             <span class="sr-only">{{ or (T .Identifier) .Name | safeHTML }}</span>
           </a>


### PR DESCRIPTION
Mastodon has a feature to display a verified link on your profile. [For this to work a rel="me" attribute has to be set on the link to the mastodon profile. ](https://joinmastodon.org/verification).

This pull request adds the rel="me" attribute to the navbar icon link if the icon is set to "mastodon".