### PR TITLE
fix(docs): add editURL.enable = true

### DIFF
--- a/exampleSite/content/docs/guide/configuration.md
+++ b/exampleSite/content/docs/guide/configuration.md
@@ -139,6 +139,7 @@ To configure the page edit link, we can set the `params.editURL.base` parameter 
 ```yaml {filename="hugo.yaml"}
 params:
   editURL:
+    enable: true
     base: "https://github.com/your-username/your-repo/edit/main"
 ```
 


### PR DESCRIPTION
The MR documents the requirement to enable editURL setting.


[A  prior commit](https://github.com/imfing/hextra/commit/04a5c7378a867111e91e3cd6425ed132889a5ad1#diff-5311bf4e1519696010f8298385d9de30210dfcd9dee8785f6deba3a084b62eecL26) the behavior changed from a default of "disable = false" to a default of "enabled = false".