### PR TITLE
showcase: clever cloud documentation

### DIFF
--- a/exampleSite/content/showcase/index.md
+++ b/exampleSite/content/showcase/index.md
@@ -16,4 +16,5 @@ Open source projects powered by Hextra.
   {{< card link="https://getporter.org/" title="Porter" image="https://repository-images.githubusercontent.com/155893691/aa249c80-fcf3-11ea-93b0-30079e8d7de4" imageStyle="object-fit:cover; aspect-ratio:16/9;" >}}
   {{< card link="https://lutheranconfessions.org/" title="LutheranConfessions" image="https://github.com/imfing/hextra/assets/5097752/ad6625e4-88cd-4cad-b102-5399997d0359" imageStyle="object-fit:cover; aspect-ratio:16/9;" >}}
   {{< card link="https://github.com/imfing/hextra-starter-template/" title="Hextra Starter Template" image="https://user-images.githubusercontent.com/5097752/263551418-c403b9a9-a76c-47a6-8466-513d772ef0b7.jpg" imageStyle="object-fit:cover; aspect-ratio:16/9;" >}}
+  {{< card link="https://developers.clever-cloud.com/" title="Clever Cloud Documentation" image="https://cellar-c2.services.clever-cloud.com/documentation/doc-screenshot.png" imageStyle="object-fit:cover; aspect-ratio:16/9;" >}}
 {{< /cards >}}


### PR DESCRIPTION
Added [Clever Cloud Documentation website](https://developers.clever-cloud.com) in the showcase page of Hextra site, as suggested [here](https://github.com/imfing/hextra/discussions/259#discussioncomment-8171964). 

Image is hosted in our storage object, to avoid weighing Hextra's site with an additional PNG, but we can relocate it in `/static` if it suits you better.

