### PR TITLE
fix: accurate `editURL` resolution in translated sites 

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -26,8 +26,18 @@
       <div class="{{ $borderClass }} sticky bottom-0 flex flex-col items-start gap-2 pb-8 dark:border-neutral-800 contrast-more:border-t contrast-more:border-neutral-400 contrast-more:shadow-none contrast-more:dark:border-neutral-400">
         {{- if site.Params.editURL.enable -}}
           {{- $editURL := site.Params.editURL.base | default "" -}}
-          {{- with .File -}}{{ $editURL = urls.JoinPath $editURL (replace .Path "\\" "/") }}{{- end -}}
-          {{- with .Params.editURL -}}{{ $editURL = . }}{{- end -}}
+          {{- with .Params.editURL -}}
+            {{/* if `editURL` is set in the front matter */}}
+            {{- $editURL = . -}}
+          {{- else -}}
+            {{- with .File -}}
+              {{/* `.FileInfo.Meta.SourceRoot` is a Hugo internal field, e.g. `/path/to/repo/content/en/` */}}
+              {{- $sourceDir := replace (strings.TrimPrefix .FileInfo.Meta.BaseDir .FileInfo.Meta.SourceRoot) "\\" "/" -}}
+              {{- $sourceDir = strings.TrimPrefix "/content" $sourceDir -}}
+              {{- $path := replace .Path "\\" "/" -}}
+              {{- $editURL = urls.JoinPath $editURL $sourceDir $path -}}
+            {{- end -}}
+          {{- end -}}
           <a class="text-xs font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 contrast-more:text-gray-800 contrast-more:dark:text-gray-50" href="{{ $editURL }}" target="_blank" rel="noreferer">{{ $editThisPage }}</a>
         {{- end -}}
         {{/* Scroll To Top */}}


### PR DESCRIPTION
Fix #228 

**Issue:**
In translated Hugo sites, `.File.Path` incorrectly pointed to the root path relative to `content/en`, failing to accurately reference the required subdirectory (`/en`).

**Solution:**
Replaced `.File.Path` with `.File.FileInfo.Meta` for correct root directory referencing. This approach uses the `SourceRoot` attribute from `.FileInfo.Meta` (e.g., `/workspaces/hextra/exampleSite/content/en`), stripping away `BaseDir` and `content` to determine the correct `sourceDir`. 
As a result, `sourceDir` is set to `en` for translated content directories or remains empty for non-translated content.

Example value for `.FileInfo.Meta`:

```
Path:“docs/advanced/comments.md”, 
PathWalk:“docs/advanced/comments.md”, OriginalFilename:"", 
BaseDir:"/workspaces/hextra/exampleSite", 
SourceRoot:"/workspaces/hextra/exampleSite/content/en"
```

---

Caveat: not sure how `sourceDir` would behave if the `content` is mounted from other directory.
