### PR TITLE
fix: clear top margin for nested list recursively

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -1702,9 +1702,9 @@ video {
   margin-bottom: 0.5rem;
 }
 /* This CSS rule targets the first nested unordered (ul) or ordered (ol) list 
-     inside the first list item (li) of any parent ul or ol. 
+     inside the list item (li) of any parent ul or ol. 
      The rule sets the top margin of the selected list to zero. */
-.content :where(ul, ol) > li:first-child > :where(ul, ol):not(:where([class~=not-prose],[class~=not-prose] *)) {
+.content :where(ul, ol) > li > :where(ul, ol):not(:where([class~=not-prose],[class~=not-prose] *)) {
   margin-top: 0px;
 }
 .content :where(kbd):not(:where([class~=not-prose],[class~=not-prose] *)) {
@@ -1804,6 +1804,7 @@ article details > summary::before {
     height: 1.2em;
     width: 1.2em;
     vertical-align: -4px;
+    padding: 0 0.6em;
   }
 /* Code syntax highlight */
 /* Light theme for syntax highlight */

--- a/assets/css/typography.css
+++ b/assets/css/typography.css
@@ -58,9 +58,9 @@
     }
   }
   /* This CSS rule targets the first nested unordered (ul) or ordered (ol) list 
-     inside the first list item (li) of any parent ul or ol. 
+     inside the list item (li) of any parent ul or ol. 
      The rule sets the top margin of the selected list to zero. */
-  :where(ul, ol) > li:first-child > :where(ul, ol):not(:where([class~=not-prose],[class~=not-prose] *)) {
+  :where(ul, ol) > li > :where(ul, ol):not(:where([class~=not-prose],[class~=not-prose] *)) {
     @apply mt-0;
   }
   :where(kbd):not(:where([class~=not-prose],[class~=not-prose] *)) {


### PR DESCRIPTION
previous pr: https://github.com/imfing/hextra/pull/276 didn't handle the nested list recursively

this PR removes the `first-child` selector so it would apply the `margin-top: 0` recursively for `<li>` elements under `content`

![image](https://github.com/imfing/hextra/assets/5097752/0c44744e-4595-45f2-a7c9-459e3800c026)

fixes #277 