### PR TITLE
feat: add parameter to empty sidebar on mobile

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -107,6 +107,9 @@ params:
     # full (100%), wide (90rem), normal (1280px)
     width: normal
 
+  sidebar:
+    emptyMobile: false
+
   theme:
     # light | dark | system
     default: system

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -22,11 +22,13 @@
     {{ partial "search.html" }}
   </div>
   <div class="hextra-scrollbar overflow-y-auto overflow-x-hidden p-4 grow md:h-[calc(100vh-var(--navbar-height)-var(--menu-height))]">
+    {{- if not site.Params.sidebar.emptyMobile -}}
     <ul class="flex flex-col gap-1 md:hidden">
       <!-- Nav -->
       {{ template "sidebar-main" (dict "context" site.Home "pageURL" $pageURL "page" $context "toc" true) -}}
       {{ template "sidebar-footer" }}
     </ul>
+    {{- end -}}
 
     <!-- Sidebar on large screen -->
     {{- if $disableSidebar -}}


### PR DESCRIPTION
Fix #274 #275

- Add `sidebar.emptyMobile` in `site.Params`
- Set it to `false` in the example site
- Add the a condition in the sidebar layout
- If the parameter is not set or false, the sidebar is shown

I check on the example site, work as expected