### PR TITLE
fix: resolve padding issue for code blocks with filenames but without lang highlight

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -2186,6 +2186,10 @@ article details > summary::before {
   --tw-text-opacity: 1;
   color: rgb(229 231 235 / var(--tw-text-opacity));
 }
+.code-block .filename + pre:not(.lntable pre) {
+    /* Override padding for code blocks with filename but no highlight */
+    padding-top: 3rem;
+  }
 .code-block pre:not(.lntable pre) {
   margin-bottom: 1rem;
   border-radius: 0.75rem;

--- a/assets/css/highlight.css
+++ b/assets/css/highlight.css
@@ -12,6 +12,11 @@
   .filename {
     @apply absolute top-0 z-[1] w-full truncate rounded-t-xl bg-primary-700/5 py-2 px-4 text-xs text-gray-700 dark:bg-primary-300/10 dark:text-gray-200;
   }
+
+  .filename + pre:not(.lntable pre) {
+    /* Override padding for code blocks with filename but no highlight */
+    @apply pt-12;
+  }
 }
 
 .code-block pre:not(.lntable pre) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -308,9 +308,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001517",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
-      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
+      "version": "1.0.30001587",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001587.tgz",
+      "integrity": "sha512-HMFNotUmLXn71BQxg8cijvqxnIAofforZOwGsxyXJ0qugTdspUF4sPSJ2vhgprHCB996tIDzEq1ubumPDV8ULA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
The padding will be displayed correctly:

![image](https://github.com/imfing/hextra/assets/5097752/a825e4f9-e0e9-4847-9a66-6919598284a7)

fixes #282 