### PR TITLE
feat: support customize flexsearch tokenize option

### DIFF
--- a/assets/js/flexsearch.js
+++ b/assets/js/flexsearch.js
@@ -172,8 +172,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // Preload the search index.
   async function preloadIndex() {
+    const tokenize = '{{- site.Params.search.flexsearch.tokenize | default  "forward" -}}';
     window.pageIndex = new FlexSearch.Document({
-      tokenize: 'forward',
+      tokenize,
       cache: 100,
       document: {
         id: 'id',
@@ -183,7 +184,7 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     window.sectionIndex = new FlexSearch.Document({
-      tokenize: 'forward',
+      tokenize,
       cache: 100,
       document: {
         id: 'id',

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -136,6 +136,9 @@ params:
     flexsearch:
       # index page by: content | summary | heading | title
       index: content
+      # full | forward | reverse | strict 
+      # https://github.com/nextapps-de/flexsearch/#tokenizer-prefix-search
+      tokenize: forward
 
   editURL:
     enable: true


### PR DESCRIPTION
The default tokenize option 'forward' for flexsearch is good, and have better performance compare with option 'full'. 
**But it can not support some partial search, so i think it may be a good idea to set up a param in `settings.yaml` for user to decide it.** 
Here are the search effect diagrams of two different configurations. The first one with option 'full' can get more results than the second one with option 'forward'.
![image](https://github.com/imfing/hextra/assets/59039948/576fbccf-899b-4422-81d4-e0e093e7ec16)
![image](https://github.com/imfing/hextra/assets/59039948/10d2b0d4-e094-4ff8-bbb4-b3e5ec645d20)
