### PR TITLE
Make copy button visible on code blocks

### DIFF
--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -13,7 +13,7 @@
   {{- else -}}
     <pre><code>{{ .Inner }}</code></pre>
   {{- end -}}
-  <div class="hx-opacity-0 hx-transition group-hover/code:hx-opacity-100 hx-flex hx-gap-1 hx-absolute hx-m-[11px] hx-right-0 {{ if $filename }}hx-top-8{{ else }}hx-top-0{{ end }}">
+  <div class="hx-opacity-80 hx-transition group-hover/code:hx-opacity-100 hx-flex hx-gap-1 hx-absolute hx-m-[11px] hx-right-0 {{ if $filename }}hx-top-8{{ else }}hx-top-0{{ end }}">
     <button
       class="code-copy-btn group/copybtn hx-transition-all active:hx-opacity-50 hx-bg-primary-700/5 hx-border hx-border-black/5 hx-text-gray-600 hover:hx-text-gray-900 hx-rounded-md hx-p-1.5 dark:hx-bg-primary-300/10 dark:hx-border-white/10 dark:hx-text-gray-400 dark:hover:hx-text-gray-50"
       title="{{ $copyCode }}"


### PR DESCRIPTION
Hello,

copy button is not visible on code blocks. Here is a screenshot from official documentation (https://imfing.github.io/hextra/docs/guide/syntax-highlighting/):

![image](https://github.com/imfing/hextra/assets/1562400/408e1190-2ed5-4bb3-a85e-1ba3f788c8dd)

This PR makes the button visible:

![image](https://github.com/imfing/hextra/assets/1562400/477f2100-443d-4c2c-b41c-836f6d28701b)


⚠️ please note I'm not satisfied with the behavior: it looks like a check mark shall be displayed for 1s after click. This is still not the case. I've tried to hack the css and js but I must admit I do not know much about tailwind & css. Probably this worths a small investigation on your side !

Thanks.