### PR TITLE
feat: add title utility to get page or section title

### DIFF
--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -2,12 +2,12 @@
   {{- range .Ancestors.Reverse }}
     {{- if not .IsHome }}
       <div class="hx-whitespace-nowrap hx-transition-colors hx-min-w-[24px] hx-overflow-hidden hx-text-ellipsis hover:hx-text-gray-900 dark:hover:hx-text-gray-100">
-        <a href="{{ .Permalink }}">{{ .LinkTitle }}</a>
+        <a href="{{ .Permalink }}">{{- partial "utils/title" . -}}</a>
       </div>
       {{- partial "utils/icon.html" (dict "name" "chevron-right" "attributes" "class=\"hx-w-3.5 hx-shrink-0 rtl:-hx-rotate-180\"") -}}
     {{ end -}}
   {{ end -}}
   <div class="hx-whitespace-nowrap hx-transition-colors hx-font-medium hx-text-gray-700 contrast-more:hx-font-bold contrast-more:hx-text-current dark:hx-text-gray-100 contrast-more:dark:hx-text-current">
-    {{- .LinkTitle -}}
+    {{- partial "utils/title" . -}}
   </div>
 </div>

--- a/layouts/partials/components/pager.html
+++ b/layouts/partials/components/pager.html
@@ -28,22 +28,24 @@
 {{- if or $prev $next -}}
   <div class="hx-mb-8 hx-flex hx-items-center hx-border-t hx-pt-8 dark:hx-border-neutral-800 contrast-more:hx-border-neutral-400 dark:contrast-more:hx-border-neutral-400 print:hx-hidden">
     {{- if $prev -}}
+      {{- $linkTitle := partial "utils/title" $prev -}}
       <a
         href="{{ $prev.RelPermalink }}"
-        title="{{ $prev.LinkTitle }}"
+        title="{{ $linkTitle }}"
         class="hx-flex hx-max-w-[50%] hx-items-center hx-gap-1 hx-py-4 hx-text-base hx-font-medium hx-text-gray-600 hx-transition-colors [word-break:break-word] hover:hx-text-primary-600 dark:hx-text-gray-300 md:hx-text-lg ltr:hx-pr-4 rtl:hx-pl-4"
       >
         {{- partial "utils/icon.html" (dict "name" "chevron-right" "attributes" "class=\"hx-inline hx-h-5 hx-shrink-0 ltr:hx-rotate-180\"") -}}
-        {{- $prev.LinkTitle -}}
+        {{- $linkTitle -}}
       </a>
     {{- end -}}
     {{- if $next -}}
+      {{- $linkTitle := partial "utils/title" $next -}}
       <a
         href="{{ $next.RelPermalink }}"
-        title="{{ $next.LinkTitle }}"
+        title="{{ $linkTitle }}"
         class="hx-flex hx-max-w-[50%] hx-items-center hx-gap-1 hx-py-4 hx-text-base hx-font-medium hx-text-gray-600 hx-transition-colors [word-break:break-word] hover:hx-text-primary-600 dark:hx-text-gray-300 md:hx-text-lg ltr:hx-ml-auto ltr:hx-pl-4 ltr:hx-text-right rtl:hx-mr-auto rtl:hx-pr-4 rtl:hx-text-left"
       >
-        {{- $next.LinkTitle -}}
+        {{- $linkTitle -}}
         {{- partial "utils/icon.html" (dict "name" "chevron-right" "attributes" "class=\"hx-inline hx-h-5 hx-shrink-0 rtl:-hx-rotate-180\"") -}}
       </a>
     {{- end -}}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -78,13 +78,14 @@
       {{- range $items.ByWeight }}
         {{- if .Params.sidebar.separator -}}
           <li class="[word-break:break-word] hx-mt-5 hx-mb-2 hx-px-2 hx-py-1.5 hx-text-sm hx-font-semibold hx-text-gray-900 first:hx-mt-0 dark:hx-text-gray-100">
-            <span class="hx-cursor-default">{{ .LinkTitle }}</span>
+            <span class="hx-cursor-default">{{ partial "utils/title" . }}</span>
           </li>
         {{- else -}}
           {{- $active := eq $pageURL .RelPermalink -}}
           {{- $shouldOpen := or (.Params.sidebar.open) (.IsAncestor $page) $active | default true }}
           <li class="{{ if $shouldOpen }}open{{ end }}">
-            {{- template "sidebar-item-link" dict "context" . "active" $active "title" .LinkTitle "link" .RelPermalink -}}
+            {{- $linkTitle := partial "utils/title" . -}}
+            {{- template "sidebar-item-link" dict "context" . "active" $active "title" $linkTitle "link" .RelPermalink -}}
             {{- if and $toc $active -}}
               {{- template "sidebar-toc" dict "page" . -}}
             {{- end -}}
@@ -98,9 +99,9 @@
           {{- range $items.ByWeight }}
             {{- $active := eq $pageURL .RelPermalink -}}
             {{- $shouldOpen := or (.Params.sidebar.open) (.IsAncestor $page) $active | default true }}
-            {{- $title := .LinkTitle | default .File.BaseFileName -}}
+            {{- $linkTitle := partial "utils/title" . -}}
             <li class="hx-flex hx-flex-col {{ if $shouldOpen }}open{{ end }}">
-              {{- template "sidebar-item-link" dict "context" . "active" $active "title" $title "link" .RelPermalink -}}
+              {{- template "sidebar-item-link" dict "context" . "active" $active "title" $linkTitle "link" .RelPermalink -}}
               {{- if and $toc $active -}}
                 {{ template "sidebar-toc" dict "page" . }}
               {{- end }}

--- a/layouts/partials/utils/title.html
+++ b/layouts/partials/utils/title.html
@@ -1,0 +1,19 @@
+{{/*
+  This utility is used to retrieve the title of a page or section.
+  If no title is set, it falls back to using the directory or file name.
+
+  Based on https://github.com/thegeeklab/hugo-geekdoc/blob/v0.44.0/layouts/partials/utils/title.html
+*/}}
+{{- $title := "" }}
+
+{{ if .LinkTitle }}
+  {{ $title = .LinkTitle }}
+{{ else if .Title }}
+  {{ $title = .Title }}
+{{ else if and .IsSection .File }}
+  {{ $title = path.Base .File.Dir | humanize | title }}
+{{ else if and .IsPage .File }}
+  {{ $title = .File.BaseFileName | humanize | title }}
+{{ end }}
+
+{{ return $title -}}


### PR DESCRIPTION
* with graceful fallback to using the directory or filename if no name is provided via the front-matter

Closes #293 

| Before | After |
|:------:|:-----:|
| ![Before](https://github.com/imfing/hextra/assets/5097752/6dc9a3c0-6a52-4bb8-841e-ed9bbd64b621) | ![After](https://github.com/imfing/hextra/assets/5097752/bffdae01-e751-4304-819c-65898e9e25bf) |
