### PR TITLE
feat: pdf shortcode (unstable)

### DIFF
--- a/layouts/partials/utils/file-path.html
+++ b/layouts/partials/utils/file-path.html
@@ -1,0 +1,21 @@
+{{/* This utility is used to get the file path from absolute, relative path or URL. */}}
+
+{{- $path := .path -}}
+{{- $page := .page -}}
+
+{{- $isLocal := not (urls.Parse $path).Scheme -}}
+{{- $isPage := and (eq $page.Kind "page") (not $page.BundleType) -}}
+{{- $startsWithSlash := hasPrefix $path "/" -}}
+{{- $startsWithRelative := hasPrefix $path "../" -}}
+
+{{- if and $path $isLocal -}}
+  {{- if $startsWithSlash -}}
+    {{/* File under static directory */}}
+    {{- $path = (relURL (strings.TrimPrefix "/" $path)) -}}
+  {{- else if and $isPage (not $startsWithRelative) -}}
+    {{/* File is a sibling to the individual page file */}}
+    {{ $path = (printf "../%s" $path) }}
+  {{- end -}}
+{{- end -}}
+
+{{- return $path -}}

--- a/layouts/shortcodes/pdf.html
+++ b/layouts/shortcodes/pdf.html
@@ -1,0 +1,9 @@
+{{/* Shortcode to include a PDF file in a page. */}}
+
+{{- $path := .Get 0 -}}
+{{- $url := partial "utils/file-path" (dict "page" .Page "path" $path) -}}
+
+
+<div class="hextra-pdf">
+  <iframe src="{{ $url | safeURL }}" width="100%" style="min-height: 32rem;" frameborder="0"></iframe>
+</div>


### PR DESCRIPTION
allow embed pdf files in a page

usage:
```
{{% pdf "dummy.pdf" %}}
```

Example:
![image](https://github.com/imfing/hextra/assets/5097752/651f1a33-3075-4d88-9deb-3b855e931460)
