### PR TITLE
feat: support sort blog post list page

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -136,7 +136,7 @@ params:
     flexsearch:
       # index page by: content | summary | heading | title
       index: content
-      # full | forward | reverse | strict 
+      # full | forward | reverse | strict
       # https://github.com/nextapps-de/flexsearch/#tokenizer-prefix-search
       tokenize: forward
 
@@ -147,6 +147,9 @@ params:
   blog:
     list:
       displayTags: true
+      # date | lastmod | publishDate | title | weight
+      sortBy: date
+      sortOrder: desc # or "asc"
 
   comments:
     enable: false

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -7,7 +7,8 @@
         <br class="hx-mt-1.5 hx-text-sm" />
         <h1 class="hx-text-center hx-mt-2 hx-text-4xl hx-font-bold hx-tracking-tight hx-text-slate-900 dark:hx-text-slate-100">{{ .Title }}</h1>
         <div class="content">{{ .Content }}</div>
-        {{ range .Pages.ByDate.Reverse }}
+        {{- $pages := partial "utils/sort-pages" (dict "page" . "by" site.Params.blog.list.sortBy "order" site.Params.blog.list.sortOrder) -}}
+        {{- range $pages }}
           <div class="hx-mb-10">
             <h3><a style="color: inherit; text-decoration: none;" class="hx-block hx-font-semibold hx-mt-8 hx-text-2xl " href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
             {{- if site.Params.blog.list.displayTags -}}
@@ -25,9 +26,9 @@
             </p>
             <p class="hx-opacity-50 hx-text-sm hx-mt-4 hx-leading-7">{{ partial "utils/format-date" .Date }}</p>
           </div>
-        {{ end }}
+        {{ end -}}
       </main>
     </article>
     <div class="max-xl:hx-hidden hx-h-0 hx-w-64 hx-shrink-0"></div>
   </div>
-{{ end }}
+{{- end -}}

--- a/layouts/partials/utils/sort-pages.html
+++ b/layouts/partials/utils/sort-pages.html
@@ -1,0 +1,32 @@
+{{- $page := .page -}}
+{{- $by := .by | default "weight" -}}
+{{- $order := .order | default "asc" -}}
+
+{{- $pages := slice }}
+
+{{- if eq $by "weight" }}
+  {{- $pages = $page.Pages.ByWeight }}
+{{- else if eq $by "date" }}
+  {{- $pages = $page.Pages.ByDate }}
+{{- else if eq $by "title" }}
+  {{- $pages = $page.Pages.ByTitle }}
+{{- else if eq $by "expiryDate" }}
+  {{- $pages = $page.Pages.ByExpiryDate }}
+{{- else if eq $by "publishDate" }}
+  {{- $pages = $page.Pages.ByPublishDate }}
+{{- else if eq $by "lastmod" }}
+  {{- $pages = $page.Pages.ByLastmod }}
+{{- else if eq $by "linkTitle" }}
+  {{- $pages = $page.Pages.ByLinkTitle }}
+{{- else if eq $by "length" }}
+  {{- $pages = $page.Pages.ByLength }}
+{{- else }}
+  {{- warnf "sort-pages: unknown sort field %q" $by -}}
+  {{- $pages = $page.Pages }}
+{{ end -}}
+
+{{- if eq $order "desc" }}
+  {{- $pages = $pages.Reverse }}
+{{- end -}}
+
+{{- return $pages -}}


### PR DESCRIPTION
config to sort blog post list page

```yaml
params:
  blog:
    list:
      displayTags: true
      # date | lastmod | publishDate | title | weight
      sortBy: date
      sortOrder: desc # or "asc"
```