### PR TITLE
docs(i18n): add zh-cn translation of RSS button

### DIFF
--- a/exampleSite/content/blog/_index.zh-cn.md
+++ b/exampleSite/content/blog/_index.zh-cn.md
@@ -1,3 +1,10 @@
 ---
 title: "博客"
 ---
+
+<div style="text-align: center; margin-top: 1em;">
+{{< hextra/hero-badge link="index.xml" >}}
+  <span>RSS 订阅</span>
+  {{< icon name="rss" attributes="height=14" >}}
+{{< /hextra/hero-badge >}}
+</div>


### PR DESCRIPTION
I notice that RSS button is missed when switching language to Chinese in the documentation of Hextra. It's added now in this PR, hope it helps.