### PR TITLE
fix: js scripts not in body element

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,6 +7,6 @@
     {{- if or (eq .Site.Params.footer.enable nil) (.Site.Params.footer.enable) }}
       {{ partial "footer.html" . }}
     {{ end }}
+    {{ partial "scripts.html" . }}
   </body>
-  {{ partial "scripts.html" . }}
 </html>


### PR DESCRIPTION
The js scripts must be in the `<body>`.