### PR TITLE
Fix: giscus.html fails when country code is specified.

### DIFF
--- a/layouts/partials/components/giscus.html
+++ b/layouts/partials/components/giscus.html
@@ -1,4 +1,4 @@
-{{- $lang := site.Language.LanguageCode | default `en` -}}
+{{- $lang := site.Language.Lang | default `en` -}}
 
 {{- with site.Params.comments.giscus -}}
 <script>


### PR DESCRIPTION
The problem is that the Giscus API fails when given `data-lang` of something like `de-DE`:

<img width="1316" alt="Screenshot 2024-04-15 at 15 40 00" src="https://github.com/imfing/hextra/assets/150670/055cee2e-0b21-4235-96e9-69aebb684864">

This fix uses just the language tag, not the whole language code: https://gohugo.io/methods/site/language/#methods

With this fix:

<img width="1392" alt="Screenshot 2024-04-15 at 15 47 13" src="https://github.com/imfing/hextra/assets/150670/d29f3264-806f-4462-abbe-6838e60669d2">
