### PR TITLE
feat: Support Hero Icons in the nav bar menu

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -56,6 +56,12 @@
             {{ if $external }}target="_blank" rel="noreferer"{{ end }}
             class="hx-text-sm contrast-more:hx-text-gray-700 contrast-more:dark:hx-text-gray-100 hx-relative -hx-ml-2 hx-hidden hx-whitespace-nowrap hx-p-2 md:hx-inline-block {{ $activeClass }}"
           >
+            {{ with .Params.hero_icon -}}
+              <span style="float: left; padding-right: 0.3em; padding-top: 2px; opacity: 0.75">
+                {{ partial "utils/icon.html" (dict "name" . "attributes" "height=18") }}
+              </span>
+            {{- end }}
+
             <span class="hx-text-center">{{ or (T .Identifier) .Name | safeHTML }}</span>
           </a>
         {{- end -}}


### PR DESCRIPTION
A Hugo `menus` config with `params.hero_icon`:

```yaml
menus:
  main:
  - identifier: discussions
    name: Forum
    url: https://github.com/dogweather/forkful/discussions
    weight: 1
    params:
      hero_icon: chat-alt-2
```

...displays the icon next to the text.

<img width="243" alt="Screenshot 2024-04-15 at 16 24 41" src="https://github.com/imfing/hextra/assets/150670/88a5b482-2046-4a26-9c2f-67306bfbdb8f">

---

I used GitHub and OpenAI as design examples for size and distance to the text. Here are more examples of combinations of icons/non-icons:

<img width="266" alt="Screenshot 2024-04-15 at 16 24 16" src="https://github.com/imfing/hextra/assets/150670/0dffe4c1-6601-4420-9195-3b3a6ae8d6ab">

<img width="291" alt="Screenshot 2024-04-15 at 16 23 52" src="https://github.com/imfing/hextra/assets/150670/7e989e7b-5f7e-4f51-9c19-3ee24c4d3797">

This code is running live here: https://forkful.ai/en/