### PR TITLE
feat: add support for `breadcrumbs` param in front matter for showing/hiding breadcrumbs on specific pages

### DIFF
--- a/exampleSite/content/docs/guide/organize-files.md
+++ b/exampleSite/content/docs/guide/organize-files.md
@@ -84,7 +84,7 @@ weight: 2
 
 ## Breadcrumb Navigation
 
-Breadcrumbs are auto-generated based on the directory structure of `/content`. 
+Breadcrumbs are auto-generated based on the directory structure of `/content`.
 
 For example, consider the file structure [demonstrated above](#directory-structure). Given that structure, the breadcrumbs atop the page at `/docs/guide/organize-files/` would appear automatically as follows:
 
@@ -112,11 +112,11 @@ Documentation > Guide > Foo Bar
 
 ### Hiding Breadcrumbs
 
-You can hide breadcrumbs completely from a page by specfying `hideBreadcrumbs: true` in its front matter:
+You can hide breadcrumbs completely from a page by specfying `breadcrumbs: false` in its front matter:
 
 ```yaml {filename="content/docs/guide/organize-files.md"}
 ---
-hideBreadcrumbs: true
+breadcrumbs: false
 title: Organize Files
 ---
 ```

--- a/exampleSite/content/docs/guide/organize-files.md
+++ b/exampleSite/content/docs/guide/organize-files.md
@@ -86,7 +86,7 @@ weight: 2
 
 Breadcrumbs are auto-generated based on the directory structure of `/content`. 
 
-For example, consider the file structure demonstrated atop this page. Given that structure, the breadcrumbs atop the page at `/docs/guide/organize-files/` would appear automatically as follows:
+For example, consider the file structure [demonstrated above](#directory-structure). Given that structure, the breadcrumbs atop the page at `/docs/guide/organize-files/` would appear automatically as follows:
 
 ```
 Documentation > Guide > Organize Files
@@ -94,17 +94,14 @@ Documentation > Guide > Organize Files
 
 ### Customizing Breadcrumb Link Titles
 
-By default, each breadcrumb link is generated based on that page's `title` parameter.
+By default, each breadcrumb link is generated based on that page's `title` parameter. You can customize this by specifying a `linkTitle`.
 
-You can customize this by specifying a `linkTitle` in that page's front matter.
-
-For example, if we wanted the breadcrumb to be `Foo Bar` instead of `Organize Files`:
+For example, if instead of `Organize Files` we wanted the breadcrumb to be `Foo Bar`:
 
 ```yaml {filename="content/docs/guide/organize-files.md"}
 ---
 linkTitle: Foo Bar
 title: Organize Files
-weight: 2
 ---
 ```
 
@@ -121,7 +118,6 @@ You can hide breadcrumbs completely from a page by specfying `hideBreadcrumbs: t
 ---
 hideBreadcrumbs: true
 title: Organize Files
-weight: 2
 ---
 ```
 

--- a/exampleSite/content/docs/guide/organize-files.md
+++ b/exampleSite/content/docs/guide/organize-files.md
@@ -82,6 +82,49 @@ weight: 2
   It is recommended to keep the sidebar not too deep. If you have a lot of content, consider **splitting them into multiple sections**.
 {{< /callout >}}
 
+## Breadcrumb Navigation
+
+Breadcrumbs are auto-generated based on the directory structure of `/content`. 
+
+For example, consider the file structure demonstrated atop this page. Given that structure, the breadcrumbs atop the page at `/docs/guide/organize-files/` would appear automatically as follows:
+
+```
+Documentation > Guide > Organize Files
+```
+
+### Customizing Breadcrumb Link Titles
+
+By default, each breadcrumb link is generated based on that page's `title` parameter.
+
+You can customize this by specifying a `linkTitle` in that page's front matter.
+
+For example, if we wanted the breadcrumb to be `Foo Bar` instead of `Organize Files`:
+
+```yaml {filename="content/docs/guide/organize-files.md"}
+---
+linkTitle: Foo Bar
+title: Organize Files
+weight: 2
+---
+```
+
+This would now generate the following breadcrumbs:
+```
+Documentation > Guide > Foo Bar
+```
+
+### Hiding Breadcrumbs
+
+You can hide breadcrumbs completely from a page by specfying `hideBreadcrumbs: true` in its front matter:
+
+```yaml {filename="content/docs/guide/organize-files.md"}
+---
+hideBreadcrumbs: true
+title: Organize Files
+weight: 2
+---
+```
+
 ## Configure Content Directory
 
 By default, the root `content/` directory is used by Hugo to build the site.

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,4 +1,4 @@
-{{- if not (default false .Params.hideBreadcrumbs) }}
+{{- if (default true .Params.breadcrumbs) }}
   <div class="hx-mt-1.5 hx-flex hx-items-center hx-gap-1 hx-overflow-hidden hx-text-sm hx-text-gray-500 dark:hx-text-gray-400 contrast-more:hx-text-current">
     {{- range .Ancestors.Reverse }}
       {{- if not .IsHome }}

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,13 +1,15 @@
-<div class="hx-mt-1.5 hx-flex hx-items-center hx-gap-1 hx-overflow-hidden hx-text-sm hx-text-gray-500 dark:hx-text-gray-400 contrast-more:hx-text-current">
-  {{- range .Ancestors.Reverse }}
-    {{- if not .IsHome }}
-      <div class="hx-whitespace-nowrap hx-transition-colors hx-min-w-[24px] hx-overflow-hidden hx-text-ellipsis hover:hx-text-gray-900 dark:hover:hx-text-gray-100">
-        <a href="{{ .Permalink }}">{{- partial "utils/title" . -}}</a>
-      </div>
-      {{- partial "utils/icon.html" (dict "name" "chevron-right" "attributes" "class=\"hx-w-3.5 hx-shrink-0 rtl:-hx-rotate-180\"") -}}
+{{- if not (default false .Params.hideBreadcrumbs) }}
+  <div class="hx-mt-1.5 hx-flex hx-items-center hx-gap-1 hx-overflow-hidden hx-text-sm hx-text-gray-500 dark:hx-text-gray-400 contrast-more:hx-text-current">
+    {{- range .Ancestors.Reverse }}
+      {{- if not .IsHome }}
+        <div class="hx-whitespace-nowrap hx-transition-colors hx-min-w-[24px] hx-overflow-hidden hx-text-ellipsis hover:hx-text-gray-900 dark:hover:hx-text-gray-100">
+          <a href="{{ .Permalink }}">{{- partial "utils/title" . -}}</a>
+        </div>
+        {{- partial "utils/icon.html" (dict "name" "chevron-right" "attributes" "class=\"hx-w-3.5 hx-shrink-0 rtl:-hx-rotate-180\"") -}}
+      {{ end -}}
     {{ end -}}
-  {{ end -}}
-  <div class="hx-whitespace-nowrap hx-transition-colors hx-font-medium hx-text-gray-700 contrast-more:hx-font-bold contrast-more:hx-text-current dark:hx-text-gray-100 contrast-more:dark:hx-text-current">
-    {{- partial "utils/title" . -}}
+    <div class="hx-whitespace-nowrap hx-transition-colors hx-font-medium hx-text-gray-700 contrast-more:hx-font-bold contrast-more:hx-text-current dark:hx-text-gray-100 contrast-more:dark:hx-text-current">
+      {{- partial "utils/title" . -}}
+    </div>
   </div>
-</div>
+{{ end-}}

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -12,4 +12,4 @@
       {{- partial "utils/title" . -}}
     </div>
   </div>
-{{ end-}}
+{{ end -}}

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -3,7 +3,7 @@
     {{- range .Ancestors.Reverse }}
       {{- if not .IsHome }}
         <div class="hx-whitespace-nowrap hx-transition-colors hx-min-w-[24px] hx-overflow-hidden hx-text-ellipsis hover:hx-text-gray-900 dark:hover:hx-text-gray-100">
-          <a href="{{ .Permalink }}">{{- partial "utils/title" . -}}</a>
+          <a href="{{ .RelPermalink }}">{{- partial "utils/title" . -}}</a>
         </div>
         {{- partial "utils/icon.html" (dict "name" "chevron-right" "attributes" "class=\"hx-w-3.5 hx-shrink-0 rtl:-hx-rotate-180\"") -}}
       {{ end -}}


### PR DESCRIPTION
Hi there! Hextra is awesome and I wanted to propose a feature that I've found useful recently: **the ability to hide breadcrumbs on specific pages.**

This has been especially useful on "index" pages, for example, where even with a custom `linkTitle` there's just not much value added from the breadcrumb.

I've also included some documentation updates for breadcrumbs in general—and for this `hideBreadcrumbs` option specifically—as I wasn't finding that information elsewhere.

## Example

### Before

|`/docs`|`/docs/processes/story-points`|
|---|---|
| At my Docs index page (`/docs`), the title `Documentation` being repeated twice by the auto-generated breadcrumbs isn't really helpful. <img width="603" alt="hextra-breadcrumbs-before-A" src="https://github.com/imfing/hextra/assets/875201/c5b36787-28d9-4814-8455-42ee88544b06"> | But it is, of course, still helpful once we get into the actual sub-pages, like `/docs/processes/story-points` in this example: <img width="615" alt="hextra-breadcrumbs-before-B" src="https://github.com/imfing/hextra/assets/875201/4a118145-cd12-43b1-9558-88202396ac9f"> |

### After

With this new `hideBreadcrumbs` param, you can have the best of both worlds.

I add it to the front matter of `/content/docs/_index.md`:
```yaml
---
hideBreadcrumbs: true
title: Documentation
weight: 10
cascade:
  type: docs
  sidebar:
    open: true
---
```

And then no longer have it on the `/docs` page, but **all the other breadcrumbs generation continues to work exactly the same.**

|`/docs`|`/docs/processes/story-points`|
|---|---|
| <img width="788" alt="hextra-breadcrumbs-after-A" src="https://github.com/imfing/hextra/assets/875201/49f97847-80e9-4ec9-8745-614cd9fba4c5"> | <img width="653" alt="hextra-breadcrumbs-after-B" src="https://github.com/imfing/hextra/assets/875201/d7752e82-2166-4322-8ccb-7e21b12f32f3"> |



