### PR TITLE
feat: add hextra hero-container shortcode

### DIFF
--- a/layouts/shortcodes/hextra/hero-container.html
+++ b/layouts/shortcodes/hextra/hero-container.html
@@ -1,9 +1,11 @@
 {{- $class := .Get "class" -}}
 {{- $cols := .Get "cols" | default 2 -}}
 {{- $image := .Get "image" -}}
+{{- $imageCard := .Get "imageCard" | default false -}}
 {{- $imageClass := .Get "imageClass" -}}
 {{- $imageLink := .Get "imageLink" -}}
 {{- $imageLinkExternal := hasPrefix $imageLink "http" -}}
+{{- $imageStyle := .Get "imageStyle" -}}
 {{- $imageTitle := .Get "imageTitle" -}}
 {{- $imageWidth := .Get "imageWidth" | default 350 -}}
 {{- $imageHeight := .Get "imageHeight" | default 350 -}}
@@ -24,12 +26,13 @@
   </div>
   {{- with $image }}
   <div class="hx-mx-auto">
-    {{ with $href }}<a href="{{ $href }}" {{ with $imageLinkExternal }}target="_blank" rel="noreferrer"{{ end }}>{{ end }}
-      <img
-        {{ with $imageClass }}class="{{ $imageClass }}"{{ end }} src="{{ $image }}" 
-        width="{{ $imageWidth }}" height="{{ $imageHeight }}" {{ with $imageTitle }}alt="{{ $imageTitle }}"{{ end }}
-      />
-    {{ with $href }}</a>{{ end }}
+    <a
+      {{ with $imageLink }}href="{{ $href }}" {{ with $imageLinkExternal }} target="_blank" rel="noreferrer"{{ end }}{{ end }}
+      {{ with $imageStyle }}style="{{ . | safeCSS }}"{{ end }}
+      class="{{ $imageClass }} {{ if $imageCard }}hextra-feature-card not-prose hx-block hx-relative hx-p-6 hx-overflow-hidden hx-rounded-3xl hx-border hx-border-gray-200 hover:hx-border-gray-300 dark:hx-border-neutral-800 dark:hover:hx-border-neutral-700 before:hx-pointer-events-none before:hx-absolute before:hx-inset-0 before:hx-bg-glass-gradient{{ end }}"
+    >
+      <img src="{{ $image }}" width="{{ $imageWidth }}" height="{{ $imageHeight }}" {{ with $imageTitle }}alt="{{ $imageTitle }}"{{ end }}/>
+    </a>
   </div>
   {{ end -}}
 </div>

--- a/layouts/shortcodes/hextra/hero-container.html
+++ b/layouts/shortcodes/hextra/hero-container.html
@@ -16,7 +16,7 @@
   class="{{ $class }} hextra-feature-grid hx-grid hx-min-w-full not-prose"
   {{ with $css }}style="{{ . | safeCSS }}"{{ end }}
 >
-  <div class="hx-mx-auto">
+  <div class="hx-w-max">
     {{ .Inner }}
   </div>
   {{- with $image }}

--- a/layouts/shortcodes/hextra/hero-container.html
+++ b/layouts/shortcodes/hextra/hero-container.html
@@ -1,0 +1,32 @@
+{{- $class := .Get "class" -}}
+{{- $cols := .Get "cols" | default 2 -}}
+{{- $image := .Get "image" -}}
+{{- $imageClass := .Get "imageClass" -}}
+{{- $imageLink := .Get "imageLink" -}}
+{{- $imageLinkExternal := hasPrefix $imageLink "http" -}}
+{{- $imageTitle := .Get "imageTitle" -}}
+{{- $imageWidth := .Get "imageWidth" | default 350 -}}
+{{- $imageHeight := .Get "imageHeight" | default 350 -}}
+{{- $style := .Get "style" -}}
+
+{{- $css := printf "--hextra-feature-grid-cols: %v; %s" $cols $style -}}
+{{- $href := cond (hasPrefix $imageLink "/") ($imageLink | relURL) $imageLink -}}
+
+<div
+  class="{{ $class }} hextra-feature-grid hx-grid sm:max-lg:hx-grid-cols-2 max-sm:hx-grid-cols-1 hx-gap-4 hx-w-max not-prose"
+  {{ with $css }}style="{{ . | safeCSS }}"{{ end }}
+>
+  <div class="grid-col-span-1">
+    {{ .Inner }}
+  </div>
+  {{- with $image }}
+  <div class="hx-mx-auto hx-px-6">
+    {{ with $href }}<a href="{{ $href }}" {{ with $imageLinkExternal }}target="_blank" rel="noreferrer"{{ end }}>{{ end }}
+      <img
+        {{ with $imageClass }}class="{{ $imageClass }}"{{ end }} src="{{ $image }}" 
+        width="{{ $imageWidth }}" height="{{ $imageHeight }}" {{ with $imageTitle }}alt="{{ $imageTitle }}"{{ end }}
+      />
+    {{ with $href }}</a>{{ end }}
+  </div>
+  {{ end -}}
+</div>

--- a/layouts/shortcodes/hextra/hero-container.html
+++ b/layouts/shortcodes/hextra/hero-container.html
@@ -21,7 +21,7 @@
   class="{{ $class }} hextra-feature-grid hx-grid sm:max-lg:hx-grid-cols-2 max-sm:hx-grid-cols-1 hx-gap-4 hx-w-full not-prose"
   {{ with $css }}style="{{ . | safeCSS }}"{{ end }}
 >
-  <div class="hx-w-full hx-mx-auto">
+  <div class="hx-w-full">
     {{ .Inner }}
   </div>
   {{- with $image }}

--- a/layouts/shortcodes/hextra/hero-container.html
+++ b/layouts/shortcodes/hextra/hero-container.html
@@ -11,6 +11,9 @@
 
 {{- $css := printf "--hextra-feature-grid-cols: %v; %s" $cols $style -}}
 {{- $href := cond (hasPrefix $imageLink "/") ($imageLink | relURL) $imageLink -}}
+{{- if hasPrefix $image "/" -}}
+  {{- $image = relURL (strings.TrimPrefix "/" $image) -}}
+{{- end -}}
 
 <div
   class="{{ $class }} hextra-feature-grid hx-grid sm:max-lg:hx-grid-cols-2 max-sm:hx-grid-cols-1 hx-gap-4 hx-w-full not-prose"

--- a/layouts/shortcodes/hextra/hero-container.html
+++ b/layouts/shortcodes/hextra/hero-container.html
@@ -21,7 +21,7 @@
   class="{{ $class }} hextra-feature-grid hx-grid sm:max-lg:hx-grid-cols-2 max-sm:hx-grid-cols-1 hx-gap-4 hx-w-full not-prose"
   {{ with $css }}style="{{ . | safeCSS }}"{{ end }}
 >
-  <div class="hx-mx-auto">
+  <div class="hx-w-full hx-mx-auto">
     {{ .Inner }}
   </div>
   {{- with $image }}

--- a/layouts/shortcodes/hextra/hero-container.html
+++ b/layouts/shortcodes/hextra/hero-container.html
@@ -13,14 +13,14 @@
 {{- $href := cond (hasPrefix $imageLink "/") ($imageLink | relURL) $imageLink -}}
 
 <div
-  class="{{ $class }} hextra-feature-grid hx-grid sm:max-lg:hx-grid-cols-2 max-sm:hx-grid-cols-1 hx-gap-4 hx-min-w-full not-prose"
+  class="{{ $class }} hextra-feature-grid hx-grid hx-min-w-full not-prose"
   {{ with $css }}style="{{ . | safeCSS }}"{{ end }}
 >
-  <div class="grid-col-span-1 hx-w-max">
+  <div class="hx-mx-auto">
     {{ .Inner }}
   </div>
   {{- with $image }}
-  <div class="hx-mx-auto hx-px-6">
+  <div class="hx-mx-auto hx-gap-4">
     {{ with $href }}<a href="{{ $href }}" {{ with $imageLinkExternal }}target="_blank" rel="noreferrer"{{ end }}>{{ end }}
       <img
         {{ with $imageClass }}class="{{ $imageClass }}"{{ end }} src="{{ $image }}" 

--- a/layouts/shortcodes/hextra/hero-container.html
+++ b/layouts/shortcodes/hextra/hero-container.html
@@ -13,10 +13,10 @@
 {{- $href := cond (hasPrefix $imageLink "/") ($imageLink | relURL) $imageLink -}}
 
 <div
-  class="{{ $class }} hextra-feature-grid hx-grid sm:max-lg:hx-grid-cols-2 max-sm:hx-grid-cols-1 hx-gap-4 hx-w-max not-prose"
+  class="{{ $class }} hextra-feature-grid hx-grid sm:max-lg:hx-grid-cols-2 max-sm:hx-grid-cols-1 hx-gap-4 hx-min-w-full not-prose"
   {{ with $css }}style="{{ . | safeCSS }}"{{ end }}
 >
-  <div class="grid-col-span-1">
+  <div class="grid-col-span-1 hx-w-max">
     {{ .Inner }}
   </div>
   {{- with $image }}

--- a/layouts/shortcodes/hextra/hero-container.html
+++ b/layouts/shortcodes/hextra/hero-container.html
@@ -1,5 +1,4 @@
 {{- $class := .Get "class" -}}
-{{- $cols := .Get "cols" | default 2 -}}
 {{- $image := .Get "image" -}}
 {{- $imageClass := .Get "imageClass" -}}
 {{- $imageLink := .Get "imageLink" -}}
@@ -9,7 +8,7 @@
 {{- $imageHeight := .Get "imageHeight" | default 350 -}}
 {{- $style := .Get "style" -}}
 
-{{- $css := printf "--hextra-feature-grid-cols: %v; %s" $cols $style -}}
+{{- $css := printf "--hextra-feature-grid-cols: %v; %s" 2 $style -}}
 {{- $href := cond (hasPrefix $imageLink "/") ($imageLink | relURL) $imageLink -}}
 
 <div

--- a/layouts/shortcodes/hextra/hero-container.html
+++ b/layouts/shortcodes/hextra/hero-container.html
@@ -1,4 +1,5 @@
 {{- $class := .Get "class" -}}
+{{- $cols := .Get "cols" | default 2 -}}
 {{- $image := .Get "image" -}}
 {{- $imageClass := .Get "imageClass" -}}
 {{- $imageLink := .Get "imageLink" -}}
@@ -8,18 +9,18 @@
 {{- $imageHeight := .Get "imageHeight" | default 350 -}}
 {{- $style := .Get "style" -}}
 
-{{- $css := printf "--hextra-feature-grid-cols: %v; %s" 2 $style -}}
+{{- $css := printf "--hextra-feature-grid-cols: %v; %s" $cols $style -}}
 {{- $href := cond (hasPrefix $imageLink "/") ($imageLink | relURL) $imageLink -}}
 
 <div
-  class="{{ $class }} hextra-feature-grid hx-grid hx-min-w-full not-prose"
+  class="{{ $class }} hextra-feature-grid hx-grid sm:max-lg:hx-grid-cols-2 max-sm:hx-grid-cols-1 hx-gap-4 hx-w-full not-prose"
   {{ with $css }}style="{{ . | safeCSS }}"{{ end }}
 >
-  <div class="hx-w-max">
+  <div class="hx-mx-auto">
     {{ .Inner }}
   </div>
   {{- with $image }}
-  <div class="hx-mx-auto hx-gap-4">
+  <div class="hx-mx-auto">
     {{ with $href }}<a href="{{ $href }}" {{ with $imageLinkExternal }}target="_blank" rel="noreferrer"{{ end }}>{{ end }}
       <img
         {{ with $imageClass }}class="{{ $imageClass }}"{{ end }} src="{{ $image }}" 


### PR DESCRIPTION
## New Feature Proposal: Hextra Hero Container

On Hextra front-page, there is a lot of unused space on the right side of headline, ideal to insert a logo image.

### Proposed Solution

I created the following `layouts/shortcodes/hextra/hero-container.html` shortcode, implementing a container with optional logo image and related link. Based on my tests, an image with `350px` height will perfectly align with the existing Hextra `badge`, `headline` and `subtile` group.

### Live Example

Visit https://axivo.com/k3s-cluster/.

### Shortcode Usage

Example of `hextra/hero-container` shortcode usage, with image pulled from `/static/images` directory:

```
{{< hextra/hero-container
  image="images/logo-services.svg"
  imageLink="https://github.com/axivo/k3s-cluster"
  imageTitle="Kubernetes Services"
>}}
{{< hextra/hero-badge link="https://github.com/axivo/k3s-cluster" >}}
  <div class="hx-w-2 hx-h-2 hx-rounded-full hx-bg-primary-400"></div>
  <span>Contribute</span>
  {{< icon name="arrow-circle-right" attributes="height=14" >}}
{{< /hextra/hero-badge >}}

<div class="hx-mt-6 hx-mb-6">
{{< hextra/hero-headline >}}
  <span class="hx-whitespace-nowrap">
    High Availability K3s Cluster
  </span><br class="sm:hx-block hx-hidden" />
  Deployed with Ansible
{{< /hextra/hero-headline >}}
</div>

<div class="hx-mb-12">
{{< hextra/hero-subtitle >}}
  <span class="hx-whitespace-nowrap">
    Documentation and tutorials to deploy, manage and monitor
  </span><br class="sm:hx-block hx-hidden" />
  your Kubernetes cluster and related components, in style.
{{< /hextra/hero-subtitle >}}
</div>

<div class="hx-mb-6">
{{< hextra/hero-button text="Get Started" link="wiki" >}}
</div>
{{< /hextra/hero-container >}}
```

### Implementation Result

With image card:

```
{{< hextra/hero-container
  image="images/logo-services.svg"
  imageCard="true" imageLink="https://github.com/axivo/k3s-cluster"
  imageStyle="background: radial-gradient(ellipse at 50% 80%,rgba(194,97,254,0.15),hsla(0,0%,100%,0));"
  imageTitle="Kubernetes Services"
>}}
```

![image](https://github.com/imfing/hextra/assets/19806136/61ce5f4a-ec02-44f9-ab00-9cf88fb3c50c)

Without image card:

```
{{< hextra/hero-container
  image="images/logo-services.svg"
  imageLink="https://github.com/axivo/k3s-cluster"
  imageTitle="Kubernetes Services"
>}}
```

![image](https://github.com/imfing/hextra/assets/19806136/38641add-e726-4899-b216-b75201fcad6f)