### PR TITLE
feat: Implement hextra hero-section

### DIFF
--- a/layouts/shortcodes/hextra/hero-section.html
+++ b/layouts/shortcodes/hextra/hero-section.html
@@ -1,8 +1,10 @@
 {{- $style := .Get "style" -}}
+{{- $header := int (strings.TrimPrefix "h" (.Get "header" | default "h2")) -}}
+{{- $size := cond (ge $header 4) "xl" (cond (eq $header 3) "2xl" "4xl") -}}
 
-<h2
-  class="not-prose hx-text-4xl hx-font-bold hx-leading-none hx-tracking-tighter md:hx-text-3xl hx-py-2 hx-bg-clip-text hx-text-transparent hx-bg-gradient-to-r hx-from-gray-900 hx-to-gray-600 dark:hx-from-gray-100 dark:hx-to-gray-400"
+<h{{ $header }}
+  class="not-prose hx-text-{{ $size }} hx-font-bold hx-leading-none hx-tracking-tighter md:hx-text-3xl hx-py-2 hx-bg-clip-text hx-text-transparent hx-bg-gradient-to-r hx-from-gray-900 hx-to-gray-600 dark:hx-from-gray-100 dark:hx-to-gray-400"
   {{ with $style }}style="{{ . | safeCSS }}"{{ end }}
 >
   {{ .Inner | markdownify }}
-</h2>
+</h{{ $header }}>

--- a/layouts/shortcodes/hextra/hero-section.html
+++ b/layouts/shortcodes/hextra/hero-section.html
@@ -1,5 +1,5 @@
 {{- $style := .Get "style" -}}
-{{- $header := int (strings.TrimPrefix "h" (.Get "header" | default "h2")) -}}
+{{- $heading := int (strings.TrimPrefix "h" (.Get "heading" | default "h2")) -}}
 {{- $size := cond (ge $header 4) "xl" (cond (eq $header 3) "2xl" "4xl") -}}
 
 <h{{ $header }}

--- a/layouts/shortcodes/hextra/hero-section.html
+++ b/layouts/shortcodes/hextra/hero-section.html
@@ -2,7 +2,7 @@
 {{- $heading := int (strings.TrimPrefix "h" (.Get "heading" | default "h2")) -}}
 {{- $size := cond (ge $header 4) "xl" (cond (eq $header 3) "2xl" "4xl") -}}
 
-<h{{ $header }}
+<h{{ $heading }}
   class="not-prose hx-text-{{ $size }} hx-font-bold hx-leading-none hx-tracking-tighter md:hx-text-3xl hx-py-2 hx-bg-clip-text hx-text-transparent hx-bg-gradient-to-r hx-from-gray-900 hx-to-gray-600 dark:hx-from-gray-100 dark:hx-to-gray-400"
   {{ with $style }}style="{{ . | safeCSS }}"{{ end }}
 >

--- a/layouts/shortcodes/hextra/hero-section.html
+++ b/layouts/shortcodes/hextra/hero-section.html
@@ -1,0 +1,8 @@
+{{- $style := .Get "style" -}}
+
+<h2
+  class="not-prose hx-text-4xl hx-font-bold hx-leading-none hx-tracking-tighter md:hx-text-3xl hx-py-2 hx-bg-clip-text hx-text-transparent hx-bg-gradient-to-r hx-from-gray-900 hx-to-gray-600 dark:hx-from-gray-100 dark:hx-to-gray-400"
+  {{ with $style }}style="{{ . | safeCSS }}"{{ end }}
+>
+  {{ .Inner | markdownify }}
+</h2>

--- a/layouts/shortcodes/hextra/hero-section.html
+++ b/layouts/shortcodes/hextra/hero-section.html
@@ -7,4 +7,4 @@
   {{ with $style }}style="{{ . | safeCSS }}"{{ end }}
 >
   {{ .Inner | markdownify }}
-</h{{ $header }}>
+</h{{ $heading }}>

--- a/layouts/shortcodes/hextra/hero-section.html
+++ b/layouts/shortcodes/hextra/hero-section.html
@@ -1,6 +1,6 @@
 {{- $style := .Get "style" -}}
 {{- $heading := int (strings.TrimPrefix "h" (.Get "heading" | default "h2")) -}}
-{{- $size := cond (ge $header 4) "xl" (cond (eq $header 3) "2xl" "4xl") -}}
+{{- $size := cond (ge $heading 4) "xl" (cond (eq $heading 3) "2xl" "4xl") -}}
 
 <h{{ $heading }}
   class="not-prose hx-text-{{ $size }} hx-font-bold hx-leading-none hx-tracking-tighter md:hx-text-3xl hx-py-2 hx-bg-clip-text hx-text-transparent hx-bg-gradient-to-r hx-from-gray-900 hx-to-gray-600 dark:hx-from-gray-100 dark:hx-to-gray-400"


### PR DESCRIPTION
## New Feature Proposal: Hero Section

On Hextra front-page, I need the ability to insert a `h2` heading, defining additional section titles. For example, adding a subtitle above `hextra/feature-grid`.

### Proposed Solution

I created the following `layouts/shortcodes/hextra/hero-section.html` shortcode, implementing a section.

### Live Example

Visit https://axivo.com/k3s-cluster/.

### Shortcode Usage

Example of `hextra/hero-section` shortcode usage, default header size is `h2`:

```
{{< hextra/hero-section >}}
  Used Technologies
{{< /hextra/hero-section >}}
```

![image](https://github.com/imfing/hextra/assets/19806136/029fd280-df0e-4a09-847b-021a1547f38c)


Example of `hextra/hero-section` shortcode usage, with `h3` header size:

```
{{< hextra/hero-section header="h3" >}}
  Used Technologies
{{< /hextra/hero-section >}}
```

![image](https://github.com/imfing/hextra/assets/19806136/9bf076d7-a504-437a-9084-e06bf6d04aef)


Example of `hextra/hero-section` shortcode usage, with `h4` or greater header size:

```
{{< hextra/hero-section header="h4" >}}
  Used Technologies
{{< /hextra/hero-section >}}
```

![image](https://github.com/imfing/hextra/assets/19806136/2a1f0a69-c18b-4d92-b48e-6e50689b0c0d)

## Frontage View  

The `Used Technologies` section title, using default `h2` header:

![image](https://github.com/imfing/hextra/assets/19806136/8a3e6ec6-f69a-41e7-8850-0394d9282029)
