### PR TITLE
fix: use `hugo.IsMultilingual` to replace deprecated `.Site.IsMultiLingual`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -57,7 +57,7 @@ We recommend that you search existing [issues][issues] or discussions before ope
 
 ### Local development setup
 
-- [Hugo][hugo] >= v0.115.0 (extended version)
+- [Hugo][hugo] >= v0.124.0 (extended version)
 - [Node.js][nodejs]
 - [Go][go]
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.124.1
+      HUGO_VERSION: 0.126.1
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -20,7 +20,7 @@
       {{- partial "language-switch.html" (dict "context" .) -}}
       {{- with $displayThemeToggle }}{{ partial "theme-toggle.html" }}{{ end -}}
     </div>
-    {{- if or site.IsMultiLingual $displayThemeToggle -}}
+    {{- if or hugo.IsMultilingual $displayThemeToggle -}}
       <hr class="dark:hx-border-neutral-800" />
     {{- end -}}
   {{- end -}}

--- a/layouts/partials/language-switch.html
+++ b/layouts/partials/language-switch.html
@@ -5,7 +5,7 @@
 
 {{- $changeLanguage := (T "changeLanguage") | default "Change language" -}}
 
-{{- if site.IsMultiLingual -}}
+{{- if hugo.IsMultilingual -}}
   <div class="hx-flex hx-justify-items-start {{ if $grow }}hx-grow{{ end }}">
     <button
       title="{{ $changeLanguage }}"

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -43,9 +43,9 @@
   {{ $switchesClass := cond $disableSidebar "md:hx-hidden" "" -}}
   {{ $displayThemeToggle := (site.Params.theme.displayToggle | default true) -}}
 
-  {{ if or site.IsMultiLingual $displayThemeToggle }}
-    <div class="{{ $switchesClass }} {{ with site.IsMultiLingual }}hx-justify-end{{ end }} hx-sticky hx-bottom-0 hx-bg-white dark:hx-bg-dark hx-mx-4 hx-py-4 hx-shadow-[0_-12px_16px_#fff] hx-flex hx-items-center hx-gap-2 dark:hx-border-neutral-800 dark:hx-shadow-[0_-12px_16px_#111] contrast-more:hx-border-neutral-400 contrast-more:hx-shadow-none contrast-more:dark:hx-shadow-none hx-border-t" data-toggle-animation="show">
-      {{- with site.IsMultiLingual -}}
+  {{ if or hugo.IsMultilingual $displayThemeToggle }}
+    <div class="{{ $switchesClass }} {{ with hugo.IsMultilingual }}hx-justify-end{{ end }} hx-sticky hx-bottom-0 hx-bg-white dark:hx-bg-dark hx-mx-4 hx-py-4 hx-shadow-[0_-12px_16px_#fff] hx-flex hx-items-center hx-gap-2 dark:hx-border-neutral-800 dark:hx-shadow-[0_-12px_16px_#111] contrast-more:hx-border-neutral-400 contrast-more:hx-shadow-none contrast-more:dark:hx-shadow-none hx-border-t" data-toggle-animation="show">
+      {{- with hugo.IsMultilingual -}}
         {{- partial "language-switch" (dict "context" $context "grow" true) -}}
         {{- with $displayThemeToggle }}{{ partial "theme-toggle" (dict "hideLabel" true) }}{{ end -}}
       {{- else -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,4 +7,6 @@ command = "cd exampleSite && hugo --gc --minify --themesDir ../.. -b ${DEPLOY_PR
 ignore = "false"
 
 [build.environment]
-HUGO_VERSION = "0.117.0"
+HUGO_VERSION = "0.126.1"
+GO_VERSION = "1.22.3"
+NODE_VERSION = "22.2.0"

--- a/theme.toml
+++ b/theme.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/imfing/hextra/"
 demosite = "https://imfing.github.io/hextra/"
 tags = ["Modern", "Elegant", "Blog", "Documentation", "Responsive", "Clean", "Light", "Dark", "Minimal"]
 features = ["Responsive", "Dark Mode", "Search", "Syntax Highlighting", "Multilingual", "Social", "Blog", "RSS", "Customization"]
-min_version = "0.111.0"
+min_version = "0.124.0"
 
 [author]
   name = "Xin"


### PR DESCRIPTION
When running the example site, a deprecation warning is shown:

```
INFO  deprecated: .Site.IsMultiLingual was deprecated in Hugo v0.124.0 and will be removed in a future release. Use hugo.IsMultilingual instead.
```

This PR fixes this warning.