### PR TITLE
docs: add missing Markdown syntax examples

### DIFF
--- a/assets/css/chroma/dark.css
+++ b/assets/css/chroma/dark.css
@@ -74,7 +74,7 @@
   /* CommentPreprocFile */ .chroma .cpf { color: #8b949e; font-weight: bold; font-style: italic }
   /* Generic */ .chroma .g {  }
   /* GenericDeleted */ .chroma .gd { color: #ffa198; background-color: #490202 }
-  /* GenericEmph */ .chroma .ge { font-style: italic }
+  /* GenericEmph */ .chroma .ge { color: inherit; font-style: italic }
   /* GenericError */ .chroma .gr { color: #ffa198 }
   /* GenericHeading */ .chroma .gh { color: #79c0ff; font-weight: bold }
   /* GenericInserted */ .chroma .gi { color: #56d364; background-color: #0f5323 }

--- a/exampleSite/content/docs/guide/markdown.fa.md
+++ b/exampleSite/content/docs/guide/markdown.fa.md
@@ -28,20 +28,40 @@ Hugo از سینتکس [مارک‌داون](https://en.wikipedia.org/wiki/Markd
 
 [^1]: نقل‌قول بالا گزیده‌ای از [سخنرانی](https://www.youtube.com/watch?v=PAAkCSZUG1c) راب پایک در Gopherfest، در تاریخ ۲۷ آبان ۱۳۹۴ است.
 
+```markdown {filename=Markdown}
+> با اشتراک‌گذاری حافظه ارتباط برقرار نکنید، حافظه را با برقراری ارتباط به اشتراک بگذارید.<br>
+> — <cite>راب پایک[^1]</cite>
+
+[^1]: نقل‌قول بالا گزیده‌ای از [سخنرانی](https://www.youtube.com/watch?v=PAAkCSZUG1c) راب پایک در Gopherfest، در تاریخ ۲۷ آبان ۱۳۹۴ است.
+```
+
 ### جدول‌ها
 
 جدول‌ها بخشی از مشخصات اصلی مارک‌داون نیستند، اما Hugo از آنها در خارج از جعبه پشتیبانی می‌کند.
 
-   نام | سن
---------|------
-    گودرز | ۳۰
-  آصف | ۳۴
+|     نام | سن  |
+|--------|------|
+|    گودرز |  ۳۰|
+|  آصف |    ۳۴  |
+
+```markdown {filename=Markdown}
+|     نام | سن  |
+|--------|------|
+|    گودرز |  ۳۰|
+|  آصف |    ۳۴  |
+```
 
 #### مارک‌داون درون‌خطی درون جدول‌ها
 
 | کج   | توپر     | کد   |
 | --------  | -------- | ------ |
 | *کج* | **توپر** | `کد` |
+
+```markdown {filename=Markdown}
+| کج   | توپر     | کد   |
+| --------  | -------- | ------ |
+| *کج* | **توپر** | `کد` |
+```
 
 ### بلوک‌های کد
 
@@ -57,11 +77,23 @@ Hugo از سینتکس [مارک‌داون](https://en.wikipedia.org/wiki/Markd
 2. دومین آیتم
 3. سومین آیتم
 
+```markdown {filename=Markdown}
+1. اولین آیتم
+2. دومین آیتم
+3. سومین آیتم
+```
+
 #### فهرست مرتب‌نشده
 
 * فهرست آیتم
 * یک آیتم دیگه
 * و یک آیتم دیگه
+
+```markdown {filename=Markdown}
+* فهرست آیتم
+* یک آیتم دیگه
+* و یک آیتم دیگه
+```
 
 #### فهرست تو در تو
 
@@ -73,13 +105,31 @@ Hugo از سینتکس [مارک‌داون](https://en.wikipedia.org/wiki/Markd
   * شیر
   * پنیر
 
+```markdown {filename=Markdown}
+* میوه
+  * سیب
+  * پرتقال
+  * موز
+* لبنیات
+  * شیر
+  * پنیر
+```
+
 ### عکس‌ها
 
-![](https://source.unsplash.com/featured/800x600?landscape)
+![landscape](https://source.unsplash.com/featured/800x600?landscape)
+
+```markdown {filename=Markdown}
+![landscape](https://source.unsplash.com/featured/800x600?landscape)
+```
 
 با توضیحات:
 
-![](https://source.unsplash.com/featured/800x600?landscape "یک چشم‌انداز Unsplash")
+![landscape](https://source.unsplash.com/featured/800x600?landscape "یک چشم‌انداز Unsplash")
+
+```markdown {filename=Markdown}
+![landscape](https://source.unsplash.com/featured/800x600?landscape "یک چشم‌انداز Unsplash")
+```
 
 ## پیکربندی
 

--- a/exampleSite/content/docs/guide/markdown.md
+++ b/exampleSite/content/docs/guide/markdown.md
@@ -28,20 +28,40 @@ Blockquote with attribution
 
 [^1]: The above quote is excerpted from Rob Pike's [talk](https://www.youtube.com/watch?v=PAAkCSZUG1c) during Gopherfest, November 18, 2015.
 
+```markdown {filename=Markdown}
+> Don't communicate by sharing memory, share memory by communicating.<br>
+> — <cite>Rob Pike[^1]</cite>
+
+[^1]: The above quote is excerpted from Rob Pike's [talk](https://www.youtube.com/watch?v=PAAkCSZUG1c) during Gopherfest, November 18, 2015.
+```
+
 ### Tables
 
 Tables aren't part of the core Markdown spec, but Hugo supports them out-of-the-box.
 
-   Name | Age
---------|------
-    Bob | 27
-  Alice | 23
+|   Name | Age  |
+|--------|------|
+|    Bob | 27   |
+|  Alice | 23   |
+
+```markdown {filename=Markdown}
+|   Name | Age  |
+|--------|------|
+|    Bob | 27   |
+|  Alice | 23   |
+```
 
 #### Inline Markdown within tables
 
 | Italics   | Bold     | Code   |
 | --------  | -------- | ------ |
 | *italics* | **bold** | `code` |
+
+```markdown {filename=Markdown}
+| Italics   | Bold     | Code   |
+| --------  | -------- | ------ |
+| *italics* | **bold** | `code` |
+```
 
 ### Code Blocks
 
@@ -57,11 +77,23 @@ Tables aren't part of the core Markdown spec, but Hugo supports them out-of-the-
 2. Second item
 3. Third item
 
+```markdown {filename=Markdown}
+1. First item
+2. Second item
+3. Third item
+```
+
 #### Unordered List
 
 * List item
 * Another item
 * And another item
+
+```markdown {filename=Markdown}
+* List item
+* Another item
+* And another item
+```
 
 #### Nested list
 
@@ -73,13 +105,31 @@ Tables aren't part of the core Markdown spec, but Hugo supports them out-of-the-
   * Milk
   * Cheese
 
+```markdown {filename=Markdown}
+* Fruit
+  * Apple
+  * Orange
+  * Banana
+* Dairy
+  * Milk
+  * Cheese
+```
+
 ### Images
 
-![](https://source.unsplash.com/featured/800x600?landscape)
+![landscape](https://source.unsplash.com/featured/800x600?landscape)
+
+```markdown {filename=Markdown}
+![landscape](https://source.unsplash.com/featured/800x600?landscape)
+```
 
 With caption:
 
-![](https://source.unsplash.com/featured/800x600?landscape "Unsplash Landscape")
+![landscape](https://source.unsplash.com/featured/800x600?landscape "Unsplash Landscape")
+
+```markdown {filename=Markdown}
+![landscape](https://source.unsplash.com/featured/800x600?landscape "Unsplash Landscape")
+```
 
 ## Configuration
 

--- a/exampleSite/content/docs/guide/markdown.zh-cn.md
+++ b/exampleSite/content/docs/guide/markdown.zh-cn.md
@@ -28,20 +28,40 @@ Hugo 支持 [Markdown](https://en.wikipedia.org/wiki/Markdown) 来书写内容�
 
 [^1]: The above quote is excerpted from Rob Pike's [talk](https://www.youtube.com/watch?v=PAAkCSZUG1c) during Gopherfest, November 18, 2015.
 
+```markdown {filename=Markdown}
+> Don't communicate by sharing memory, share memory by communicating.<br>
+> — <cite>Rob Pike[^1]</cite>
+
+[^1]: The above quote is excerpted from Rob Pike's [talk](https://www.youtube.com/watch?v=PAAkCSZUG1c) during Gopherfest, November 18, 2015.
+```
+
 ### 表格
 
 表格并非核心 Markdown 规范，但 Hugo 支持开箱即用的表格：
 
-   Name | Age
---------|------
-    Bob | 27
-  Alice | 23
+|   Name | Age  |
+|--------|------|
+|    Bob | 27   |
+|  Alice | 23   |
+
+```markdown {filename=Markdown}
+|   Name | Age  |
+|--------|------|
+|    Bob | 27   |
+|  Alice | 23   |
+```
 
 #### Markdown 表格中的内联
 
 | Italics   | Bold     | Code   |
 | --------  | -------- | ------ |
 | *italics* | **bold** | `code` |
+
+```markdown {filename=Markdown}
+| Italics   | Bold     | Code   |
+| --------  | -------- | ------ |
+| *italics* | **bold** | `code` |
+```
 
 ### 代码块
 
@@ -57,11 +77,23 @@ Hugo 支持 [Markdown](https://en.wikipedia.org/wiki/Markdown) 来书写内容�
 2. Second item
 3. Third item
 
+```markdown {filename=Markdown}
+1. First item
+2. Second item
+3. Third item
+```
+
 #### 无序列表
 
 * List item
 * Another item
 * And another item
+
+```markdown {filename=Markdown}
+* List item
+* Another item
+* And another item
+```
 
 #### 嵌套列表
 
@@ -73,13 +105,31 @@ Hugo 支持 [Markdown](https://en.wikipedia.org/wiki/Markdown) 来书写内容�
   * Milk
   * Cheese
 
+```markdown {filename=Markdown}
+* Fruit
+  * Apple
+  * Orange
+  * Banana
+* Dairy
+  * Milk
+  * Cheese
+```
+
 ### 图片
 
-![](https://source.unsplash.com/featured/800x600?landscape)
+![landscape](https://source.unsplash.com/featured/800x600?landscape)
+
+```markdown {filename=Markdown}
+![landscape](https://source.unsplash.com/featured/800x600?landscape)
+```
 
 带有标题：
 
-![](https://source.unsplash.com/featured/800x600?landscape "Unsplash Landscape")
+![landscape](https://source.unsplash.com/featured/800x600?landscape "Unsplash Landscape")
+
+```markdown {filename=Markdown}
+![landscape](https://source.unsplash.com/featured/800x600?landscape "Unsplash Landscape")
+```
 
 ## 配置
 


### PR DESCRIPTION
* Added missing MD boxes showing how to define rendered examples.
* Made the emphasis syntax visible when using the dark mode. 
* Fixed a few _markdownlint_ issues.