### PR TITLE
DOC: Add pdf shortcode documentation 

### DIFF
--- a/exampleSite/content/docs/guide/shortcodes/pdf.md
+++ b/exampleSite/content/docs/guide/shortcodes/pdf.md
@@ -1,0 +1,18 @@
+---
+title: PDF
+---
+
+## Example
+{{< pdf "https://dagrs.berkeley.edu/sites/default/files/2020-01/sample.pdf" >}}
+
+## Usage
+
+### With URL
+```
+{{< pdf "https://dagrs.berkeley.edu/sites/default/files/2020-01/sample.pdf" >}}
+``` 
+
+### With Path 
+```
+{{< pdf "path/to/your/pdf/file.pdf" >}}
+``` 

--- a/exampleSite/content/docs/guide/shortcodes/pdf.md
+++ b/exampleSite/content/docs/guide/shortcodes/pdf.md
@@ -7,11 +7,11 @@ title: Pdf
 
 ## Usage
 ### With URL
-```markdown
+```
 {{</* pdf "https://dagrs.berkeley.edu/sites/default/files/2020-01/sample.pdf" */>}}
 ``` 
 
 ### With Path 
-```markdown
+```
 {{</* pdf "path/to/your/pdf/file.pdf" */>}}
 ``` 

--- a/exampleSite/content/docs/guide/shortcodes/pdf.md
+++ b/exampleSite/content/docs/guide/shortcodes/pdf.md
@@ -1,18 +1,17 @@
 ---
-title: PDF
+title: Pdf
 ---
 
 ## Example
 {{< pdf "https://dagrs.berkeley.edu/sites/default/files/2020-01/sample.pdf" >}}
 
 ## Usage
-
 ### With URL
-```
+```markdown
 {{< pdf "https://dagrs.berkeley.edu/sites/default/files/2020-01/sample.pdf" >}}
 ``` 
 
 ### With Path 
-```
+```markdown
 {{< pdf "path/to/your/pdf/file.pdf" >}}
 ``` 

--- a/exampleSite/content/docs/guide/shortcodes/pdf.md
+++ b/exampleSite/content/docs/guide/shortcodes/pdf.md
@@ -8,10 +8,10 @@ title: Pdf
 ## Usage
 ### With URL
 ```markdown
-{{< pdf "https://dagrs.berkeley.edu/sites/default/files/2020-01/sample.pdf" >}}
+{{</* pdf "https://dagrs.berkeley.edu/sites/default/files/2020-01/sample.pdf" */>}}
 ``` 
 
 ### With Path 
 ```markdown
-{{< pdf "path/to/your/pdf/file.pdf" >}}
+{{</* pdf "path/to/your/pdf/file.pdf" */>}}
 ``` 


### PR DESCRIPTION
Added missing documentation for the pdf shortcode.

---

I was conflicted whether to use an external URL or reference a path for the example.
On one hand it's more stable to include a sample pdf file in the repo and referencing it from the example, but on the other hand adding a few bytes for each `git clone` from now on can hurt the performance of CI/CD pipelines.

Ended up with using an external URL, but it won't be difficult changing it.

Another more "stable" option is to upload the sample pdf file to a github comment and to reference that URL instead of a completely external one.