### PR TITLE
fix: remove deprecated google analytics reference in head.html

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -30,12 +30,11 @@
   {{ partialCached "head-css.html" . }}
 
 
-  <!-- Google Analytics -->
-  {{- if and (eq hugo.Environment "production") (or .Site.GoogleAnalytics .Site.Config.Services.GoogleAnalytics.ID) }}
-    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
-    {{ partial "google-analytics.html" . }}
-  {{- end }}
-
+<!-- Google Analytics -->
+{{- if and (eq hugo.Environment "production") .Site.Config.Services.GoogleAnalytics.ID }}
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
+  {{ partial "google-analytics.html" . }}
+{{- end }}
 
   <script>
     /* Initialize light/dark mode */


### PR DESCRIPTION
Fix:

```
ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.133.0.
 Use .Site.Config.Services.GoogleAnalytics.ID instead.
```