### PR TITLE
docs: update image examples with Lorem Picsum

### DIFF
--- a/exampleSite/content/docs/guide/markdown.fa.md
+++ b/exampleSite/content/docs/guide/markdown.fa.md
@@ -117,18 +117,18 @@ Hugo از سینتکس [مارک‌داون](https://en.wikipedia.org/wiki/Markd
 
 ### عکس‌ها
 
-![landscape](https://source.unsplash.com/featured/800x600?landscape)
+![landscape](https://picsum.photos/800/600)
 
 ```markdown {filename=Markdown}
-![landscape](https://source.unsplash.com/featured/800x600?landscape)
+![landscape](https://picsum.photos/800/600)
 ```
 
 با توضیحات:
 
-![landscape](https://source.unsplash.com/featured/800x600?landscape "یک چشم‌انداز Unsplash")
+![landscape](https://picsum.photos/800/600 "یک چشم‌انداز Unsplash")
 
 ```markdown {filename=Markdown}
-![landscape](https://source.unsplash.com/featured/800x600?landscape "یک چشم‌انداز Unsplash")
+![landscape](https://picsum.photos/800/600 "یک چشم‌انداز Unsplash")
 ```
 
 ## پیکربندی

--- a/exampleSite/content/docs/guide/markdown.md
+++ b/exampleSite/content/docs/guide/markdown.md
@@ -117,18 +117,18 @@ Tables aren't part of the core Markdown spec, but Hugo supports them out-of-the-
 
 ### Images
 
-![landscape](https://source.unsplash.com/featured/800x600?landscape)
+![landscape](https://picsum.photos/800/600)
 
 ```markdown {filename=Markdown}
-![landscape](https://source.unsplash.com/featured/800x600?landscape)
+![landscape](https://picsum.photos/800/600)
 ```
 
 With caption:
 
-![landscape](https://source.unsplash.com/featured/800x600?landscape "Unsplash Landscape")
+![landscape](https://picsum.photos/800/600 "Unsplash Landscape")
 
 ```markdown {filename=Markdown}
-![landscape](https://source.unsplash.com/featured/800x600?landscape "Unsplash Landscape")
+![landscape](https://picsum.photos/800/600 "Unsplash Landscape")
 ```
 
 ## Configuration

--- a/exampleSite/content/docs/guide/markdown.zh-cn.md
+++ b/exampleSite/content/docs/guide/markdown.zh-cn.md
@@ -117,18 +117,18 @@ Hugo 支持 [Markdown](https://en.wikipedia.org/wiki/Markdown) 来书写内容�
 
 ### 图片
 
-![landscape](https://source.unsplash.com/featured/800x600?landscape)
+![landscape](https://picsum.photos/800/600)
 
 ```markdown {filename=Markdown}
-![landscape](https://source.unsplash.com/featured/800x600?landscape)
+![landscape](https://picsum.photos/800/600)
 ```
 
 带有标题：
 
-![landscape](https://source.unsplash.com/featured/800x600?landscape "Unsplash Landscape")
+![landscape](https://picsum.photos/800/600 "Unsplash Landscape")
 
 ```markdown {filename=Markdown}
-![landscape](https://source.unsplash.com/featured/800x600?landscape "Unsplash Landscape")
+![landscape](https://picsum.photos/800/600 "Unsplash Landscape")
 ```
 
 ## 配置


### PR DESCRIPTION
[Unsplash Source is deprecated and being sunsetted](https://unsplash.com/documentation/changelog#unsplash-source-sunset). There is no longer a way to retrieve a random Unsplash image by URL.

[Lorem Picsum](https://picsum.photos) offers a comparable free image API with URL fetching.

This PR replaces the broken Unsplash links with Lorem Picsum links.