### PR TITLE
feat: add tooltips to cards

### DIFF
--- a/exampleSite/content/docs/guide/shortcodes/cards.md
+++ b/exampleSite/content/docs/guide/shortcodes/cards.md
@@ -7,8 +7,8 @@ linkTitle: Cards
 
 {{< cards >}}
   {{< card link="../callout" title="Callout" icon="warning" >}}
-  {{< card link="../callout" title="Card with tag" icon="tag" tag="custom tag">}}
-  {{< card link="/" title="No Icon" >}}
+  {{< card link="../callout" title="Card with tag" icon="tag" tag="A custom tag with Tooltip" tagtooltip="Tooltip for Tag">}}
+  {{< card link="/" title="No Icon, but with Tooltip" linktooltip="Tooltip for Link" >}}
 {{< /cards >}}
 
 {{< cards >}}
@@ -22,8 +22,8 @@ linkTitle: Cards
 ```
 {{</* cards */>}}
   {{</* card link="../callout" title="Callout" icon="warning" */>}}
-  {{</* card link="../callout" title="Card with tag" icon="warning" tag= "A custom tag" */>}}
-  {{</* card link="/" title="No Icon" */>}}
+  {{</* card link="../callout" title="Card with tag" tag="A custom tag with Tooltip" tagtooltip="Tooltip for Tag" */>}}
+  {{</* card link="/" title="No Icon, but with Tooltip" linktooltip="Tooltip for Link" */>}}
 {{</* /cards */>}}
 ```
 
@@ -37,14 +37,16 @@ linkTitle: Cards
 
 ## Card Parameters
 
-| Parameter  | Description                                                     |
-|----------- |-----------------------------------------------------------------|
-| `link`     | URL (internal or external).                                     |
-| `title`    | Title heading for the card.                                     |
-| `subtitle` | Subtitle heading (supports Markdown).                           |
-| `icon`     | Name of the icon.                                               |
-| `tag`      | Text in tag.                                                    |
-| `tagColor` | Color of the tag: `gray` (default), `yellow`, `red` and `blue`. |
+| Parameter     | Description                                                           |
+|---------------|-----------------------------------------------------------------------|
+| `link`        | URL (internal or external).                                           |
+| `title`       | Title heading for the card.                                           |
+| `linktooltip` | Tooltip (title-attribut) for the link.                                |
+| `subtitle`    | Subtitle heading (supports Markdown).                                 |
+| `icon`        | Name of the icon.                                                     |
+| `tag`         | Text in tag.                                                          |
+| `tagType`     | Type of the tag: `info` (blue), `warning` (yellow) and `error` (red). |
+| `tagtooltip`  | Tooltip (title-attribut) for the Tag.                                 |
   
 ## Image Card
 

--- a/layouts/partials/shortcodes/card.html
+++ b/layouts/partials/shortcodes/card.html
@@ -1,6 +1,7 @@
 {{- $page := .page -}}
 {{- $link := .link -}}
 {{- $title := .title -}}
+{{- $linktooltip := .linktooltip -}}
 {{- $icon := .icon -}}
 {{- $subtitle := .subtitle -}}
 {{- $image := .image -}}
@@ -9,6 +10,7 @@
 {{- $imageStyle := .imageStyle -}}
 {{- $tag := .tag -}}
 {{- $tagType := .tagType -}}
+{{- $tagtooltip := .tagtooltip -}}
 
 {{ $linkClass := "hover:hx-border-gray-300 hx-bg-transparent hx-shadow-sm dark:hx-border-neutral-800 hover:hx-bg-slate-50 hover:hx-shadow-md dark:hover:hx-border-neutral-700 dark:hover:hx-bg-neutral-900" }}
 {{- with $image -}}
@@ -25,6 +27,7 @@
     href="{{ $href }}"
     {{ with $external }}target="_blank" rel="noreferrer"{{ end -}}
   {{- end -}}
+  {{- with $linktooltip }}title="{{- . -}}"{{ end -}}
 >
   {{- with $image -}}
     <img
@@ -61,7 +64,7 @@
 
     {{ $tagClass := cond (eq $tagType "info") $infoClass (cond (eq $tagType "warning") $warningClass (cond (eq $tagType "error") $errorClass $defaultClass)) }}
     <div class="hextra-card-tag">
-      <span class="hx-inline-block hx-rounded-full hx-px-2.5 hx-leading-6 {{ $tagClass }}">{{ $tag }}</span>
+      <span class="hx-inline-block hx-rounded-full hx-px-2.5 hx-leading-6 {{ $tagClass }}" {{- with $tagtooltip }}title="{{- . -}}"{{ end -}} >{{ $tag }}</span>
     </div>
   {{- end -}}
 </a>

--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -1,6 +1,7 @@
 {{- $context := . -}}
 {{- $link := .Get "link" -}}
 {{- $title := .Get "title" -}}
+{{- $linktooltip := .Get "linktooltip" -}}
 {{- $icon := .Get "icon" -}}
 {{- $subtitle := .Get "subtitle" -}}
 {{- $image := .Get "image" -}}
@@ -9,6 +10,7 @@
 {{- $imageStyle := .Get "imageStyle" -}}
 {{- $tag := .Get "tag" -}}
 {{- $tagType := .Get "tagType" -}}
+{{- $tagtooltip := .Get "tagtooltip" -}}
 
 {{/* Image processing options */}}
 {{- $method := .Get "method" | default "Resize" | humanize -}}
@@ -44,6 +46,7 @@
   "page"        .Page
   "link"        $link
   "title"       $title
+  "linktooltip" $linktooltip
   "icon"        $icon
   "subtitle"    $subtitle
   "image"       $image
@@ -52,5 +55,6 @@
   "imageStyle"  $imageStyle
   "tag"         $tag
   "tagType"     $tagType
+  "tagtooltip"  $tagtooltip
   )
 -}}


### PR DESCRIPTION
### Partial implementation of #444:
#### Added 2 Params to shortcode `card`:

- linktooltip
![Hextra: Tooltip for Link](https://github.com/user-attachments/assets/53ed275f-bd75-411c-9b7a-534e07f938b4)
  
- tagtooltip
![Hextra: Tooltip for Tag](https://github.com/user-attachments/assets/38658b34-db9e-4b33-8d43-a1846c426b2d)



#### open TODOs
-  Add Documentation to `fa` and `zh-cn`
- Maybe Styling in Dark-Mode