### PR TITLE
docs: fix incorrect icon in example

### DIFF
--- a/exampleSite/content/docs/guide/shortcodes/cards.md
+++ b/exampleSite/content/docs/guide/shortcodes/cards.md
@@ -22,7 +22,7 @@ linkTitle: Cards
 ```
 {{</* cards */>}}
   {{</* card link="../callout" title="Callout" icon="warning" */>}}
-  {{</* card link="../callout" title="Card with tag" icon="warning" tag= "A custom tag" */>}}
+  {{</* card link="../callout" title="Card with tag" icon="tag" tag= "A custom tag" */>}}
   {{</* card link="/" title="No Icon" */>}}
 {{</* /cards */>}}
 ```


### PR DESCRIPTION
The `tag` icon was incorrectly shown in the example as being `warning`, which can be confusing when trying to correlate the two.