### PR TITLE
feat: scroll selected sidebar entry into view

### DIFF
--- a/assets/js/sidebar.js
+++ b/assets/js/sidebar.js
@@ -1,4 +1,9 @@
 document.addEventListener("DOMContentLoaded", function () {
+  scrollToActiveItem();
+  enableCollapsibles();
+});
+
+function enableCollapsibles() {
   const buttons = document.querySelectorAll(".hextra-sidebar-collapsible-button");
   buttons.forEach(function (button) {
     button.addEventListener("click", function (e) {
@@ -9,4 +14,23 @@ document.addEventListener("DOMContentLoaded", function () {
       }
     });
   });
-});
+}
+
+function scrollToActiveItem() {
+  const sidebarScrollbar = document.querySelector("aside.sidebar-container > .hextra-scrollbar");
+  const activeItems = document.querySelectorAll(".sidebar-active-item");
+  const visibleActiveItem = Array.from(activeItems).find(function (activeItem) {
+    return activeItem.getBoundingClientRect().height > 0;
+  });
+
+  if (!visibleActiveItem) {
+    return;
+  }
+
+  const yOffset = visibleActiveItem.clientHeight;
+  const yDistance = visibleActiveItem.getBoundingClientRect().top - sidebarScrollbar.getBoundingClientRect().top;
+  sidebarScrollbar.scrollTo({
+    behavior: "instant",
+    top: yDistance - yOffset
+  });
+}


### PR DESCRIPTION
Long sidebars did not scroll to show the selected entry. This made working with such long sidebars quite confusing.

QAed using 10+ copies of `exampleSite/content/docs/guide/shortcodes/callout.md`.

Fixes #395