### PR TITLE
feat: show breadcrumbs in search results

### DIFF
--- a/assets/js/flexsearch.js
+++ b/assets/js/flexsearch.js
@@ -233,7 +233,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         const crumbData = data[searchUrl];
         if (!crumbData) {
-          console.warn('Empty page data for', searchUrl, ', will produce incomplete breadcrumb title for section in search results.');
+          console.warn('Empty or excluded page', searchUrl, ', will not be included for search result breadcrumb for', route);
           continue;
         }
 

--- a/assets/js/flexsearch.js
+++ b/assets/js/flexsearch.js
@@ -222,18 +222,17 @@ document.addEventListener("DOMContentLoaded", function () {
     for (const route in data) {
       let pageContent = '';
       ++pageId;
-
       const urlParts = route.split('/').filter(x => x != "" && !x.startsWith('#'));
+
       let crumb = '';
       let searchUrl = '/'
-
       for (let i = 0; i < urlParts.length; i++) {
         const urlPart = urlParts[i];
         searchUrl += urlPart + '/'
 
         const crumbData = data[searchUrl];
         if (!crumbData) {
-          console.warn('Empty or excluded page', searchUrl, ', will not be included for search result breadcrumb for', route);
+          console.warn('Excluded page', searchUrl, '- will not be included for search result breadcrumb for', route);
           continue;
         }
 
@@ -250,7 +249,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
       for (const heading in data[route].data) {
         const [hash, text] = heading.split('#');
-        const url = route.trimEnd('/') + (hash ? '#' + hash : '')
+        const url = route.trimEnd('/') + (hash ? '#' + hash : '');
         const title = text || data[route].title;
 
         const content = data[route].data[heading] || '';

--- a/assets/js/flexsearch.js
+++ b/assets/js/flexsearch.js
@@ -233,7 +233,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         const crumbData = data[searchUrl];
         if (!crumbData) {
-          console.warn('No data for', searchUrl, ', will produce incomplete section title in search results.');
+          console.warn('Empty page data for', searchUrl, ', will produce incomplete breadcrumb title for section in search results.');
           continue;
         }
 

--- a/assets/js/flexsearch.js
+++ b/assets/js/flexsearch.js
@@ -323,7 +323,6 @@ document.addEventListener("DOMContentLoaded", function () {
 
       for (let j = 0; j < sectionResults.length; j++) {
         const { doc } = sectionResults[j]
-        console.log(doc)
         const isMatchingTitle = doc.display !== undefined
         if (isMatchingTitle) {
           pageTitleMatches[i]++

--- a/assets/json/search-data.json
+++ b/assets/json/search-data.json
@@ -7,7 +7,6 @@
 
 {{- $pages := where .Site.Pages "Kind" "in" (slice "page" "section") -}}
 {{- $pages = where $pages "Params.excludeSearch" "!=" true -}}
-{{- $pages = where $pages "Content" "!=" "" -}}
 
 {{- $output := dict -}}
 


### PR DESCRIPTION
* Resolve https://github.com/imfing/hextra/issues/469

Shows breadcrumbs instead of the page title for each section of the search results.

For some reason `data` can be incomplete on [our site](https://github.com/netduma/knowledge-base), I need to figure out why exactly.