### PR TITLE
fix: add back empty content filter in search-data.json

### DIFF
--- a/assets/json/search-data.json
+++ b/assets/json/search-data.json
@@ -7,6 +7,7 @@
 
 {{- $pages := where .Site.Pages "Kind" "in" (slice "page" "section") -}}
 {{- $pages = where $pages "Params.excludeSearch" "!=" true -}}
+{{- $pages = where $pages "Content" "!=" "" -}}
 
 {{- $output := dict -}}
 


### PR DESCRIPTION
- this PR reverted the change introduced in #473 which causes a nil pointer dereference issue reported in #478 and https://github.com/imfing/hextra/discussions/481
- will need a reproducible example to investigate the root cause in the future