### PR TITLE
add cellular_raza to showcase exampleSite

### DIFF
--- a/exampleSite/content/showcase/index.md
+++ b/exampleSite/content/showcase/index.md
@@ -15,7 +15,7 @@ Open source projects powered by Hextra
   {{< card
         link="https://github.com/jonaspleyer/cellular_raza"
         title="cellular_raza"
-        image="/images/cellular_raza.png"
+        image="https://github.com/user-attachments/assets/f24c6455-b70a-419b-b025-e3d60101b673"
         imageStyle="object-fit:cover; aspect-ratio:16/9;"
   >}}
 

--- a/exampleSite/content/showcase/index.md
+++ b/exampleSite/content/showcase/index.md
@@ -13,6 +13,13 @@ Open source projects powered by Hextra
 
 {{< cards >}}
   {{< card
+        link="https://github.com/jonaspleyer/cellular_raza"
+        title="cellular_raza"
+        image="/images/cellular_raza.png"
+        imageStyle="object-fit:cover; aspect-ratio:16/9;"
+  >}}
+
+  {{< card
         link="https://github.com/mightymoud/sidekick"
         title="Sidekick"
         image="https://github.com/user-attachments/assets/4ae2a9d7-77b6-42eb-a9d7-5c4599f0f812"


### PR DESCRIPTION
Hi,
Thank you for this really nice hugo theme. I would love to add the documentation website of my simulation tool `cellular_raza` to the showcase site.
I was unsure where to put the image so I simply included it in the static folder but I assume that this is not the correct place. Please let me know where to put it.