### PR TITLE
feat: support theme toggle in navbar.

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -31,6 +31,8 @@
     {{- range .Site.Menus.main -}}
       {{- if eq .Params.type "search" -}}
         {{- partial "search.html" (dict "params" .Params) -}}
+      {{- else if eq .Params.type "theme-toggle" -}}
+        {{- partial "theme-toggle.html" (dict "hideLabel" (.Params.hideLabel | default true)) -}}
       {{- else -}}
         {{- $link := .URL -}}
         {{- $external := strings.HasPrefix $link "http" -}}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -32,7 +32,7 @@
       {{- if eq .Params.type "search" -}}
         {{- partial "search.html" (dict "params" .Params) -}}
       {{- else if eq .Params.type "theme-toggle" -}}
-        {{- partial "theme-toggle.html" (dict "hideLabel" (.Params.hideLabel | default true)) -}}
+        {{- partial "theme-toggle.html" (dict "navbar" true "hideLabel" (.Params.hideLabel | default true)) -}}
       {{- else -}}
         {{- $link := .URL -}}
         {{- $external := strings.HasPrefix $link "http" -}}

--- a/layouts/partials/theme-toggle.html
+++ b/layouts/partials/theme-toggle.html
@@ -1,3 +1,6 @@
+{{- $navbar := .navbar | default false -}}
+{{- $height := 12 -}}
+{{- if $navbar -}}{{- $height = 24 -}}{{- end -}}
 {{- $hideLabel := .hideLabel | default false -}}
 
 {{- $changeTheme := (T "changeTheme") | default "Change theme" -}}
@@ -13,9 +16,9 @@
   aria-label="{{ $changeTheme }}"
 >
   <div class="hx-flex hx-items-center hx-gap-2 hx-capitalize">
-    {{- partial "utils/icon.html" (dict "name" "sun" "attributes" "height=12 class=\"group-data-[theme=light]:hx-hidden\"") -}}
+    {{- partial "utils/icon.html" (dict "name" "sun" "attributes" (printf "height=%d class=\"group-data-[theme=light]:hx-hidden\"" $height)) -}}
     {{- if not $hideLabel }}<span class="group-data-[theme=light]:hx-hidden">{{ $light }}</span>{{ end -}}
-    {{- partial "utils/icon.html" (dict "name" "moon" "attributes" "height=12 class=\"group-data-[theme=dark]:hx-hidden\"") -}}
+    {{- partial "utils/icon.html" (dict "name" "moon" "attributes" (printf "height=%d class=\"group-data-[theme=dark]:hx-hidden\"" $height)) -}}
     {{- if not $hideLabel }}<span class="group-data-[theme=dark]:hx-hidden">{{ $dark }}</span>{{ end -}}
   </div>
 </button>

--- a/layouts/partials/theme-toggle.html
+++ b/layouts/partials/theme-toggle.html
@@ -1,6 +1,10 @@
 {{- $navbar := .navbar | default false -}}
-{{- $height := 12 -}}
-{{- if $navbar -}}{{- $height = 24 -}}{{- end -}}
+{{- $height_px := 12 -}}
+{{- $height_tw := "hx-text-xs" -}}
+{{- if $navbar -}}
+  {{- $height_px = 24 -}}
+  {{- $height_tw = "hx-text-sm" -}}
+{{- end -}}
 {{- $hideLabel := .hideLabel | default false -}}
 
 {{- $changeTheme := (T "changeTheme") | default "Change theme" -}}
@@ -11,14 +15,14 @@
 <button
   title="{{ $changeTheme }}"
   data-theme="light"
-  class="theme-toggle hx-group hx-h-7 hx-rounded-md hx-px-2 hx-text-left hx-text-xs hx-font-medium hx-text-gray-600 hx-transition-colors dark:hx-text-gray-400 hover:hx-bg-gray-100 hover:hx-text-gray-900 dark:hover:hx-bg-primary-100/5 dark:hover:hx-text-gray-50"
+  class="theme-toggle hx-group hx-h-7 hx-rounded-md hx-px-2 hx-text-left {{ $height_tw }} hx-font-medium hx-text-gray-600 hx-transition-colors dark:hx-text-gray-400 hover:hx-bg-gray-100 hover:hx-text-gray-900 dark:hover:hx-bg-primary-100/5 dark:hover:hx-text-gray-50"
   type="button"
   aria-label="{{ $changeTheme }}"
 >
   <div class="hx-flex hx-items-center hx-gap-2 hx-capitalize">
-    {{- partial "utils/icon.html" (dict "name" "sun" "attributes" (printf "height=%d class=\"group-data-[theme=light]:hx-hidden\"" $height)) -}}
+    {{- partial "utils/icon.html" (dict "name" "sun" "attributes" (printf "height=%d class=\"group-data-[theme=light]:hx-hidden\"" $height_px)) -}}
     {{- if not $hideLabel }}<span class="group-data-[theme=light]:hx-hidden">{{ $light }}</span>{{ end -}}
-    {{- partial "utils/icon.html" (dict "name" "moon" "attributes" (printf "height=%d class=\"group-data-[theme=dark]:hx-hidden\"" $height)) -}}
+    {{- partial "utils/icon.html" (dict "name" "moon" "attributes" (printf "height=%d class=\"group-data-[theme=dark]:hx-hidden\"" $height_px)) -}}
     {{- if not $hideLabel }}<span class="group-data-[theme=dark]:hx-hidden">{{ $dark }}</span>{{ end -}}
   </div>
 </button>


### PR DESCRIPTION
- Add additional logic for navbar partial.
- Uses a menu item params.type of `theme-toggle`.
- Uses additional params.hideLabel boolean to set hideLabel for the theme-toggle.html partial; defaults to true.

Addresses #343 .