### PR TITLE
feat: add giscus theme customization

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -173,3 +173,4 @@ params:
       # emitMetadata: 0
       # inputPosition: top
       # lang: en
+      # theme: noborder_dark

--- a/layouts/partials/components/giscus.html
+++ b/layouts/partials/components/giscus.html
@@ -8,8 +8,17 @@
    * This solution was created with reference to:
    * https://github.com/giscus/giscus/issues/336#issuecomment-1214366281
   */
-  function getGiscusTheme() {
+  function getHugoTheme() {
     return localStorage.getItem("color-theme");
+  }
+  
+  function getGiscusTheme() {
+    let giscusTheme = "{{ (string .theme) | default `light` }}";
+    if(getHugoTheme() == 'light') {
+      return giscusTheme.replace('dark', 'light');
+    } else {
+      return giscusTheme.replace('light', 'dark');
+    }
   }
 
   function setGiscusTheme() {


### PR DESCRIPTION
To customize your giscus theme, select a theme from [https://giscus.app/](https://giscus.app/) and update the relevant option in the `hugo.yaml` file.

```yaml
params:
  comments:
    giscus:
      theme: noborder_light    #  dark_high_contrast  |  dark_protanopia  |  cobalt  |  etc.
```

<img width="392" alt="Screenshot 2024-12-22 at 02 20 09" src="https://github.com/user-attachments/assets/5fb24b9c-38ab-430b-8cea-d0e4ba188e08" />

---

Related issue #521