### PR TITLE
feat: support link in code block title

### DIFF
--- a/exampleSite/content/docs/guide/syntax-highlighting.md
+++ b/exampleSite/content/docs/guide/syntax-highlighting.md
@@ -40,6 +40,23 @@ def say_hello():
     print("Hello!")
 ```
 
+### Link to file
+
+In addition to file name you can provide base URL in attribute `filename_uri_base`, which would be concatenated with the file name to render a link.
+
+Note that filename can be relative to the base path, if you would like file name to contain path in which it is located:
+
+````markdown {filename="Markdown"}
+```go {filename_uri_base="https://github.com/imfing/hextra/blob/main/",filename="exampleSite/hugo.work"}
+go 1.20
+```
+````
+
+
+```go {filename_uri_base="https://github.com/imfing/hextra/blob/main/",filename="exampleSite/hugo.work"}
+go 1.20
+```
+
 ### Line Numbers
 
 To set line numbers, set attribute `linenos` to `table` and optionally set `linenostart` to the starting line number:

--- a/exampleSite/content/docs/guide/syntax-highlighting.md
+++ b/exampleSite/content/docs/guide/syntax-highlighting.md
@@ -40,20 +40,19 @@ def say_hello():
     print("Hello!")
 ```
 
-### Link to file
+### Link to File
 
-In addition to file name you can provide base URL in attribute `filename_uri_base`, which would be concatenated with the file name to render a link.
+You can use the `base_url` attribute to provide a base URL that will be combined with the file name to generate a link.
 
-Note that filename can be relative to the base path, if you would like file name to contain path in which it is located:
+The file name can include a relative path if it specifies the file's location within the base path.
 
 ````markdown {filename="Markdown"}
-```go {filename_uri_base="https://github.com/imfing/hextra/blob/main/",filename="exampleSite/hugo.work"}
+```go {base_url="https://github.com/imfing/hextra/blob/main/",filename="exampleSite/hugo.work"}
 go 1.20
 ```
 ````
 
-
-```go {filename_uri_base="https://github.com/imfing/hextra/blob/main/",filename="exampleSite/hugo.work"}
+```go {base_url="https://github.com/imfing/hextra/blob/main/",filename="exampleSite/hugo.work"}
 go 1.20
 ```
 

--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,10 +1,11 @@
 {{- $class := .Attributes.class | default "" -}}
 {{- $filename := .Attributes.filename | default "" -}}
+{{- $filename_uri_base := .Attributes.filename_uri_base | default "" -}}
 {{- $lang := .Attributes.lang | default .Type -}}
 
 
 <div class="hextra-code-block hx-relative hx-mt-6 first:hx-mt-0 hx-group/code">
-  {{ partial "components/codeblock" (dict "filename" $filename "lang" $lang "content" .Inner "options" .Options) }}
+  {{ partial "components/codeblock" (dict "filename" $filename "lang" $lang "filename_uri_base" $filename_uri_base "content" .Inner "options" .Options) }}
 
   {{- if or (eq site.Params.highlight.copy.enable nil) (site.Params.highlight.copy.enable) }}
     {{- partialCached "components/codeblock-copy-button" (dict "filename" $filename) $filename }}

--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,13 +1,13 @@
 {{- $class := .Attributes.class | default "" -}}
 {{- $filename := .Attributes.filename | default "" -}}
-{{- $filename_uri_base := .Attributes.filename_uri_base | default "" -}}
+{{- $base_url := .Attributes.base_url | default "" -}}
 {{- $lang := .Attributes.lang | default .Type -}}
 
 
 <div class="hextra-code-block hx-relative hx-mt-6 first:hx-mt-0 hx-group/code">
-  {{ partial "components/codeblock" (dict "filename" $filename "lang" $lang "filename_uri_base" $filename_uri_base "content" .Inner "options" .Options) }}
+  {{- partial "components/codeblock" (dict "filename" $filename "lang" $lang "base_url" $base_url "content" .Inner "options" .Options) -}}
 
-  {{- if or (eq site.Params.highlight.copy.enable nil) (site.Params.highlight.copy.enable) }}
-    {{- partialCached "components/codeblock-copy-button" (dict "filename" $filename) $filename }}
-  {{ end }}
+  {{- if or (eq site.Params.highlight.copy.enable nil) (site.Params.highlight.copy.enable) -}}
+    {{- partialCached "components/codeblock-copy-button" (dict "filename" $filename) $filename -}}
+  {{- end -}}
 </div>

--- a/layouts/partials/components/codeblock.html
+++ b/layouts/partials/components/codeblock.html
@@ -5,24 +5,23 @@
 {{ $options := .options | default (dict) }}
 
 {{- if $filename -}}
-  <div class="filename" dir="auto">
+  <div class="filename not-prose" dir="auto">
     {{- if $filename_uri_base -}}
-      {{- $attributes := "height=1em"}}
-      {{- $icon := index site.Data.icons "external-link" -}}
-      {{- $icon = replaceRE "<svg" (printf "<svg %s" $attributes) $icon -}}
-      {{- $baseEndsWithSlash := hasSuffix $filename_uri_base "/" -}}
-      {{- $filename_uri_base = cond $baseEndsWithSlash ( substr $filename_uri_base 0 -1 ) $filename_uri_base -}}
-      {{- $filenameStartsWithSlash := hasPrefix $filename "/" -}}
-      {{- $filename = cond $filenameStartsWithSlash ( substr $filename 1 ) $filename -}}
-      <a style="color: inherit; text-decoration: none;" href="{{ $filename_uri_base }}/{{ $filename }}" target="_blank" rel="noopener noreferrer">
-          {{ $filename }}
-          <span class="hx-inline-block hx-align-text-bottom icon">{{- $icon | safeHTML -}}</span>
+
+      {{- $filename_uri_base = strings.TrimSuffix "/" $filename_uri_base -}}
+      {{- $filename = strings.TrimPrefix "/" $filename -}}
+      {{- $file_uri := urls.JoinPath $filename_uri_base $filename -}}
+
+      <a class="hx-no-underline hx-inline-flex hx-items-center hx-gap-1" href="{{ $file_uri }}" target="_blank" rel="noopener noreferrer">
+          {{- $filename -}}
+          {{- partial "utils/icon" (dict "name" "external-link" "attributes" "height=1em") -}}
       </a>
     {{- else -}}
-      {{ $filename }}
+      {{- $filename -}}
     {{- end -}}
   </div>
 {{- end -}}
+
 {{- if transform.CanHighlight $lang -}}
   <div>{{- highlight $content $lang $options -}}</div>
 {{- else -}}

--- a/layouts/partials/components/codeblock.html
+++ b/layouts/partials/components/codeblock.html
@@ -1,10 +1,27 @@
 {{ $filename := .filename | default "" -}}
+{{ $filename_uri_base := .filename_uri_base | default "" -}}
 {{ $lang := .lang | default "" }}
 {{ $content := .content }}
 {{ $options := .options | default (dict) }}
 
 {{- if $filename -}}
-  <div class="filename" dir="auto">{{ $filename }}</div>
+  <div class="filename" dir="auto">
+    {{- if $filename_uri_base -}}
+      {{- $attributes := "height=1em"}}
+      {{- $icon := index site.Data.icons "external-link" -}}
+      {{- $icon = replaceRE "<svg" (printf "<svg %s" $attributes) $icon -}}
+      {{- $baseEndsWithSlash := hasSuffix $filename_uri_base "/" -}}
+      {{- $filename_uri_base = cond $baseEndsWithSlash ( substr $filename_uri_base 0 -1 ) $filename_uri_base -}}
+      {{- $filenameStartsWithSlash := hasPrefix $filename "/" -}}
+      {{- $filename = cond $filenameStartsWithSlash ( substr $filename 1 ) $filename -}}
+      <a style="color: inherit; text-decoration: none;" href="{{ $filename_uri_base }}/{{ $filename }}" target="_blank" rel="noopener noreferrer">
+          {{ $filename }}
+          <span class="hx-inline-block hx-align-text-bottom icon">{{- $icon | safeHTML -}}</span>
+      </a>
+    {{- else -}}
+      {{ $filename }}
+    {{- end -}}
+  </div>
 {{- end -}}
 {{- if transform.CanHighlight $lang -}}
   <div>{{- highlight $content $lang $options -}}</div>

--- a/layouts/partials/components/codeblock.html
+++ b/layouts/partials/components/codeblock.html
@@ -1,19 +1,19 @@
 {{ $filename := .filename | default "" -}}
-{{ $filename_uri_base := .filename_uri_base | default "" -}}
+{{ $base_url := .base_url | default "" -}}
 {{ $lang := .lang | default "" }}
 {{ $content := .content }}
 {{ $options := .options | default (dict) }}
 
 {{- if $filename -}}
   <div class="filename not-prose" dir="auto">
-    {{- if $filename_uri_base -}}
+    {{- if $base_url -}}
 
-      {{- $filename_uri_base = strings.TrimSuffix "/" $filename_uri_base -}}
+      {{- $base_url = strings.TrimSuffix "/" $base_url -}}
       {{- $filename = strings.TrimPrefix "/" $filename -}}
-      {{- $file_uri := urls.JoinPath $filename_uri_base $filename -}}
+      {{- $file_url := urls.JoinPath $base_url $filename -}}
 
-      <a class="hx-no-underline hx-inline-flex hx-items-center hx-gap-1" href="{{ $file_uri }}" target="_blank" rel="noopener noreferrer">
-          {{- $filename -}}
+      <a class="hx-no-underline hx-inline-flex hx-items-center hx-gap-1" href="{{ $file_url }}" target="_blank" rel="noopener noreferrer">
+          <span>{{- $filename -}}</span>
           {{- partial "utils/icon" (dict "name" "external-link" "attributes" "height=1em") -}}
       </a>
     {{- else -}}


### PR DESCRIPTION
This introduces new attribute `filename_uri_base` that adds to codeblock rendering a feature allowing to render a link from the code block title to wherever the sources could be looked up.

![image](https://github.com/user-attachments/assets/2064fcac-36e0-479a-9ba4-9554fdfd3620)

UPD: you can see it here: https://deploy-preview-523--hugo-hextra.netlify.app/docs/guide/syntax-highlighting/#link-to-file