### PR TITLE
refactor: use generic .Process for card processing and allow bundled images

### DIFF
--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -38,4 +38,4 @@
   "tag"         $tag
   "tagType"     $tagType
   )
--}
+-}}

--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -9,14 +9,17 @@
 {{- $imageStyle := .Get "imageStyle" -}}
 {{- $tag := .Get "tag" -}}
 {{- $tagType := .Get "tagType" -}}
+{{/* hugo process argument string /*}}
 {{- $process := .Get "process" | default "resize 800x webp q80" -}}
 
 {{- with or (.Page.Resources.Get $image) (resources.Get $image) -}}
+  {{/* Retrieve the $image resource from local or global resources */}}
   {{- $processed := .Process $process -}}
   {{- $width = $processed.Width -}}
   {{- $height = $processed.Height -}}
   {{- $image = $processed.RelPermalink -}}
 {{ else }}
+  {{/* Otherwise, use relative link of the image */}}
   {{- if hasPrefix $image "/" -}}
     {{- $image = relURL (strings.TrimPrefix "/" $image) -}}
   {{- end -}}

--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -9,34 +9,16 @@
 {{- $imageStyle := .Get "imageStyle" -}}
 {{- $tag := .Get "tag" -}}
 {{- $tagType := .Get "tagType" -}}
+{{- $process := .Get "process" | default "resize 800x webp q80" -}}
 
-{{/* Image processing options */}}
-{{- $method := .Get "method" | default "Resize" | humanize -}}
-{{- $options := .Get "options" | default "800x webp q80" -}}
-
-{{- if and $image (not (urls.Parse $image).Scheme) -}}
-  {{/* Process images in assets */}}
-  {{- with resources.Get $image -}}
-    {{- $processed := "" -}}
-    {{- if eq $method "Resize" -}}
-      {{- $processed = (.Resize $options) -}}
-    {{- else if eq $method "Fit" -}}
-      {{- $processed = (.Fit $options) -}}
-    {{- else if eq $method "Fill" -}}
-      {{- $processed = (.Fill $options) -}}
-    {{- else if eq $method "Crop" -}}
-      {{- $processed = (.Crop $options) -}}
-    {{- else -}}
-      {{- errorf "Invalid image processing command: Must be one of Crop, Fit, Fill or Resize." -}}
-    {{- end -}}
-    {{- $width = $processed.Width -}}
-    {{- $height = $processed.Height -}}
-    {{- $image = $processed.RelPermalink -}}
-  {{- else -}}
-    {{/* Otherwise, use relative link of the image */}}
-    {{- if hasPrefix $image "/" -}}
-      {{- $image = relURL (strings.TrimPrefix "/" $image) -}}
-    {{- end -}}
+{{- with or (.Page.Resources.Get $image) (resources.Get $image) -}}
+  {{- $processed := .Process $process -}}
+  {{- $width = $processed.Width -}}
+  {{- $height = $processed.Height -}}
+  {{- $image = $processed.RelPermalink -}}
+{{ else }}
+  {{- if hasPrefix $image "/" -}}
+    {{- $image = relURL (strings.TrimPrefix "/" $image) -}}
   {{- end -}}
 {{- end -}}
 
@@ -53,4 +35,4 @@
   "tag"         $tag
   "tagType"     $tagType
   )
--}}
+-}

--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -13,7 +13,7 @@
 {{/* Image processing options */}}
 {{- $method := .Get "method" | default "Resize" | humanize -}}
 {{- $options := .Get "options" | default "800x webp q80" -}}
-{{- $process := .Get "process" | default (delimit (slice $method $options) " " " ") -}}
+{{- $process := .Get "process" | default (printf "%s %s" $method $options) -}}
 
 {{- with or (.Page.Resources.Get $image) (resources.Get $image) -}}
   {{/* Retrieve the $image resource from local or global resources */}}

--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -9,8 +9,11 @@
 {{- $imageStyle := .Get "imageStyle" -}}
 {{- $tag := .Get "tag" -}}
 {{- $tagType := .Get "tagType" -}}
-{{/* hugo process argument string /*}}
-{{- $process := .Get "process" | default "resize 800x webp q80" -}}
+
+{{/* Image processing options */}}
+{{- $method := .Get "method" | default "Resize" | humanize -}}
+{{- $options := .Get "options" | default "800x webp q80" -}}
+{{- $process := .Get "process" | default (delimit (slice $method $options) " " " ") -}}
 
 {{- with or (.Page.Resources.Get $image) (resources.Get $image) -}}
   {{/* Retrieve the $image resource from local or global resources */}}


### PR DESCRIPTION
This PR changes the processing of the given card $image to the more generic [.Process](https://gohugo.io/content-management/image-processing/#image-processing-options) method available from hugo v0.119.0.
It allows to process both global images from assets as well as local/page bundle images.

resolves #103 
