### PR TITLE
fix: skip image process on svgs and remote images

### DIFF
--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -15,16 +15,21 @@
 {{- $options := .Get "options" | default "800x webp q80" -}}
 {{- $process := .Get "process" | default (printf "%s %s" $method $options) -}}
 
-{{- with or (.Page.Resources.Get $image) (resources.Get $image) -}}
-  {{/* Retrieve the $image resource from local or global resources */}}
-  {{- $processed := .Process $process -}}
-  {{- $width = $processed.Width -}}
-  {{- $height = $processed.Height -}}
-  {{- $image = $processed.RelPermalink -}}
-{{ else }}
-  {{/* Otherwise, use relative link of the image */}}
-  {{- if hasPrefix $image "/" -}}
-    {{- $image = relURL (strings.TrimPrefix "/" $image) -}}
+{{- if and $image (not (urls.Parse $image).Scheme) -}}
+  {{- with or (.Page.Resources.Get $image) (resources.Get $image) -}}
+    {{/* .Process does not work on svgs */}}
+    {{- if (not (eq .MediaType.SubType "svg")) -}}
+      {{/* Retrieve the $image resource from local or global resources */}}
+      {{- $processed := .Process $process -}}
+      {{- $width = $processed.Width -}}
+      {{- $height = $processed.Height -}}
+      {{- $image = $processed.RelPermalink -}}
+    {{- end -}}
+  {{ else }}
+    {{/* Otherwise, use relative link of the image */}}
+    {{- if hasPrefix $image "/" -}}
+      {{- $image = relURL (strings.TrimPrefix "/" $image) -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
This commit attempts to fix a bug (#549) introduced by switching to Hugo's generic .Process method (see #103).
It skips processing on remote resources and does not process local .svgs either.
