### PR TITLE
fix: Misaligned page title when logo is not displayed

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -19,11 +19,11 @@
   <nav class="hx-mx-auto hx-flex hx-items-center hx-justify-end hx-gap-2 hx-h-16 hx-px-6 {{ $navWidth }}">
     <a class="hx-flex hx-items-center hover:hx-opacity-75 ltr:hx-mr-auto rtl:hx-ml-auto" href="{{ $logoLink }}">
       {{- if (.Site.Params.navbar.displayLogo | default true) }}
-        <img class="hx-block dark:hx-hidden" src="{{ $logoPath | relURL }}" alt="{{ .Site.Title }}" height="{{ $logoHeight }}" width="{{ $logoWidth }}" />
-        <img class="hx-hidden dark:hx-block" src="{{ $logoDarkPath | relURL }}" alt="{{ .Site.Title }}" height="{{ $logoHeight }}" width="{{ $logoWidth }}" />
+        <img class="hx-mr-2 hx-block dark:hx-hidden" src="{{ $logoPath | relURL }}" alt="{{ .Site.Title }}" height="{{ $logoHeight }}" width="{{ $logoWidth }}" />
+        <img class="hx-mr-2 hx-hidden dark:hx-block" src="{{ $logoDarkPath | relURL }}" alt="{{ .Site.Title }}" height="{{ $logoHeight }}" width="{{ $logoWidth }}" />
       {{- end }}
       {{- if (.Site.Params.navbar.displayTitle | default true) }}
-        <span class="hx-mx-2 hx-font-extrabold hx-inline hx-select-none" title="{{ .Site.Title }}">{{- .Site.Title -}}</span>
+        <span class="hx-mr-2 hx-font-extrabold hx-inline hx-select-none" title="{{ .Site.Title }}">{{- .Site.Title -}}</span>
       {{- end }}
     </a>
 


### PR DESCRIPTION
When the navbar is configured not to show a logo, the page title still has a small margin on the left side. When the page content is configured to have the same width as the navbar (e.g. `wide`), this leads to a misalignment between the left edge of the page title and the left edge of the side navigation. This PR fixes that by moving the margin onto the logo element, so that the margin is not there when the logo is not there.

## Screenshots

### Before
![screenshot before the change, the page title is not aligned with the side navigation](https://github.com/user-attachments/assets/e4257f34-ce32-4a18-b67e-12bf2c772518)

### After
![screenshot after the change, the page title is aligned with the side navigation](https://github.com/user-attachments/assets/64619b3a-3929-443a-a91e-0b2455b2dc8d)
