### PR TITLE
refactor: modularize scripts partial into separate components

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -5,7 +5,12 @@
 {{- partial "scripts/search.html" . -}}
 
 {{/* Mermaid */}}
-{{- partial "scripts/mermaid.html" . -}}
+{{/* FIXME: need to investigate .Page.Store hasMermaid is set for homepage */}}
+{{- if and (.Page.Store.Get "hasMermaid") (not .Page.IsHome) -}}
+  {{- partial "scripts/mermaid.html" . -}}
+{{- end -}}
 
 {{/* KaTex */}}
-{{- partial "scripts/katex.html" . -}}
+{{- if .Page.Params.math -}}
+  {{- partial "scripts/katex.html" . -}}
+{{- end -}}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,104 +1,11 @@
-{{- $jsTheme := resources.Get "js/theme.js" | resources.ExecuteAsTemplate "theme.js" . -}}
-{{- $jsMenu := resources.Get "js/menu.js" -}}
-{{- $jsTabs := resources.Get "js/tabs.js" -}}
-{{- $jsLang := resources.Get "js/lang.js" -}}
-{{- $jsCodeCopy := resources.Get "js/code-copy.js" -}}
-{{- $jsFileTree := resources.Get "js/filetree.js" -}}
-{{- $jsSidebar := resources.Get "js/sidebar.js" -}}
-{{- $jsBackToTop := resources.Get "js/back-to-top.js" -}}
-
-{{- $scripts := slice $jsTheme $jsMenu $jsCodeCopy $jsTabs $jsLang $jsFileTree $jsSidebar $jsBackToTop | resources.Concat "js/main.js" -}}
-{{- if hugo.IsProduction -}}
-  {{- $scripts = $scripts | minify | fingerprint -}}
-{{- end -}}
-<script defer src="{{ $scripts.RelPermalink }}" integrity="{{ $scripts.Data.Integrity }}"></script>
-
+{{/* Core scripts (theme, menu, tabs, etc.) */}}
+{{- partial "scripts/core.html" . -}}
 
 {{/* Search */}}
-{{- if (site.Params.search.enable | default true) -}}
-  {{- $searchType := site.Params.search.type | default "flexsearch" -}}
-  {{- if eq $searchType "flexsearch" -}}
-    {{- $jsSearchScript := printf "%s.search.js" .Language.Lang -}}
-    {{- $jsSearch := resources.Get "js/flexsearch.js" | resources.ExecuteAsTemplate $jsSearchScript . -}}
-    {{- if hugo.IsProduction -}}
-      {{- $jsSearch = $jsSearch | minify | fingerprint -}}
-    {{- end -}}
-    {{- $flexSearchJS := resources.Get "lib/flexsearch/flexsearch.bundle.min.js" | fingerprint -}}
-    <script defer src="{{ $flexSearchJS.RelPermalink }}" integrity="{{ $flexSearchJS.Data.Integrity }}"></script>
-    <script defer src="{{ $jsSearch.RelPermalink }}" integrity="{{ $jsSearch.Data.Integrity }}"></script>
-  {{- else -}}
-    {{- warnf `search type "%s" is not supported` $searchType -}}
-  {{- end -}}
-{{- end -}}
+{{- partial "scripts/search.html" . -}}
 
 {{/* Mermaid */}}
-{{/* FIXME: need to investigate .Page.Store hasMermaid is set for homepage */}}
-{{- if and (.Page.Store.Get "hasMermaid") (not .Page.IsHome) -}}
-  {{- $mermaidJS := resources.Get "lib/mermaid/mermaid.min.js" | fingerprint -}}
-  <script defer src="{{ $mermaidJS.RelPermalink }}" integrity="{{ $mermaidJS.Data.Integrity }}"></script>
-  <script>
-    document.addEventListener("DOMContentLoaded", () => {
-      // Store original mermaid code for each diagram
-      document.querySelectorAll(".mermaid").forEach(el => {
-        el.dataset.original = el.innerHTML;
-      });
-
-      const theme = document.documentElement.classList.contains("dark") ? "dark" : "default";
-      mermaid.initialize({ startOnLoad: true, theme: theme });
-
-      let timeout;
-      new MutationObserver(() => {
-        clearTimeout(timeout);
-        timeout = setTimeout(() => {
-          const theme = document.documentElement.classList.contains("dark") ? "dark" : "default";
-          document.querySelectorAll(".mermaid").forEach(el => {
-            // Reset to original content, preserving HTML
-            el.innerHTML = el.dataset.original;
-            el.removeAttribute("data-processed");
-          });
-          mermaid.initialize({ startOnLoad: true, theme: theme });
-          mermaid.init();
-        }, 150);
-      }).observe(document.documentElement, {
-        attributes: true,
-        attributeFilter: ["class"]
-      });
-    });
-  </script>
-{{- end -}}
+{{- partial "scripts/mermaid.html" . -}}
 
 {{/* KaTex */}}
-{{- if .Page.Params.math -}}
-  {{- $katexCSS := resources.Get "lib/katex/katex.min.css" | fingerprint -}}
-  {{- $katexJS := resources.Get "lib/katex/katex.min.js" | fingerprint -}}
-  {{- $mhchemJS := resources.Get "lib/katex/mhchem.min.js" | fingerprint -}}
-  {{- $katexAutoRenderJS := resources.Get "lib/katex/auto-render.min.js" | fingerprint -}}
-  <link type="text/css" rel="stylesheet" href="{{ $katexCSS.RelPermalink }}" integrity="{{ $katexCSS.Data.Integrity }}" />
-  <script defer src="{{ $katexJS.RelPermalink }}" integrity="{{ $katexJS.Data.Integrity }}"></script>
-  <script defer src="{{ $katexAutoRenderJS.RelPermalink }}" integrity="{{ $katexAutoRenderJS.Data.Integrity }}"></script>
-  <script defer src="{{ $mhchemJS.RelPermalink }}" integrity="{{ $mhchemJS.Data.Integrity }}"></script>
-  {{ $katexFonts := resources.Match "lib/katex/fonts/*" }}
-  {{- range $katexFonts -}}
-    {{ .Publish }}
-  {{- end -}}
-  <script>
-    // TODO: make render options configurable
-    // Reference: https://katex.org/docs/autorender#api
-    document.addEventListener("DOMContentLoaded", function () {
-      renderMathInElement(document.body, {
-        delimiters: [
-          { left: "$$", right: "$$", display: true },
-          { left: "$", right: "$", display: false },
-          { left: "\\(", right: "\\)", display: false },
-          { left: "\\begin{equation}", right: "\\end{equation}", display: true },
-          {left: "\\begin{align}", right: "\\end{align}", display: true},
-          {left: "\\begin{alignat}", right: "\\end{alignat}", display: true},
-          {left: "\\begin{gather}", right: "\\end{gather}", display: true},
-          {left: "\\begin{CD}", right: "\\end{CD}", display: true},
-          { left: "\\[", right: "\\]", display: true },
-        ],
-        throwOnError: false,
-      });
-    });
-  </script>
-{{ end }}
+{{- partial "scripts/katex.html" . -}}

--- a/layouts/partials/scripts/core.html
+++ b/layouts/partials/scripts/core.html
@@ -1,0 +1,14 @@
+{{- $jsTheme := resources.Get "js/theme.js" | resources.ExecuteAsTemplate "theme.js" . -}}
+{{- $jsMenu := resources.Get "js/menu.js" -}}
+{{- $jsTabs := resources.Get "js/tabs.js" -}}
+{{- $jsLang := resources.Get "js/lang.js" -}}
+{{- $jsCodeCopy := resources.Get "js/code-copy.js" -}}
+{{- $jsFileTree := resources.Get "js/filetree.js" -}}
+{{- $jsSidebar := resources.Get "js/sidebar.js" -}}
+{{- $jsBackToTop := resources.Get "js/back-to-top.js" -}}
+
+{{- $scripts := slice $jsTheme $jsMenu $jsCodeCopy $jsTabs $jsLang $jsFileTree $jsSidebar $jsBackToTop | resources.Concat "js/main.js" -}}
+{{- if hugo.IsProduction -}}
+  {{- $scripts = $scripts | minify | fingerprint -}}
+{{- end -}}
+<script defer src="{{ $scripts.RelPermalink }}" integrity="{{ $scripts.Data.Integrity }}"></script>

--- a/layouts/partials/scripts/katex.html
+++ b/layouts/partials/scripts/katex.html
@@ -1,35 +1,33 @@
 {{/* KaTex */}}
-{{- if .Page.Params.math -}}
-  {{- $katexCSS := resources.Get "lib/katex/katex.min.css" | fingerprint -}}
-  {{- $katexJS := resources.Get "lib/katex/katex.min.js" | fingerprint -}}
-  {{- $mhchemJS := resources.Get "lib/katex/mhchem.min.js" | fingerprint -}}
-  {{- $katexAutoRenderJS := resources.Get "lib/katex/auto-render.min.js" | fingerprint -}}
-  <link type="text/css" rel="stylesheet" href="{{ $katexCSS.RelPermalink }}" integrity="{{ $katexCSS.Data.Integrity }}" />
-  <script defer src="{{ $katexJS.RelPermalink }}" integrity="{{ $katexJS.Data.Integrity }}"></script>
-  <script defer src="{{ $katexAutoRenderJS.RelPermalink }}" integrity="{{ $katexAutoRenderJS.Data.Integrity }}"></script>
-  <script defer src="{{ $mhchemJS.RelPermalink }}" integrity="{{ $mhchemJS.Data.Integrity }}"></script>
-  {{ $katexFonts := resources.Match "lib/katex/fonts/*" }}
-  {{- range $katexFonts -}}
-    {{ .Publish }}
-  {{- end -}}
-  <script>
-    // TODO: make render options configurable
-    // Reference: https://katex.org/docs/autorender#api
-    document.addEventListener("DOMContentLoaded", function () {
-      renderMathInElement(document.body, {
-        delimiters: [
-          { left: "$$", right: "$$", display: true },
-          { left: "$", right: "$", display: false },
-          { left: "\\(", right: "\\)", display: false },
-          { left: "\\begin{equation}", right: "\\end{equation}", display: true },
-          {left: "\\begin{align}", right: "\\end{align}", display: true},
-          {left: "\\begin{alignat}", right: "\\end{alignat}", display: true},
-          {left: "\\begin{gather}", right: "\\end{gather}", display: true},
-          {left: "\\begin{CD}", right: "\\end{CD}", display: true},
-          { left: "\\[", right: "\\]", display: true },
-        ],
-        throwOnError: false,
-      });
+{{- $katexCSS := resources.Get "lib/katex/katex.min.css" | fingerprint -}}
+{{- $katexJS := resources.Get "lib/katex/katex.min.js" | fingerprint -}}
+{{- $mhchemJS := resources.Get "lib/katex/mhchem.min.js" | fingerprint -}}
+{{- $katexAutoRenderJS := resources.Get "lib/katex/auto-render.min.js" | fingerprint -}}
+<link type="text/css" rel="stylesheet" href="{{ $katexCSS.RelPermalink }}" integrity="{{ $katexCSS.Data.Integrity }}" />
+<script defer src="{{ $katexJS.RelPermalink }}" integrity="{{ $katexJS.Data.Integrity }}"></script>
+<script defer src="{{ $katexAutoRenderJS.RelPermalink }}" integrity="{{ $katexAutoRenderJS.Data.Integrity }}"></script>
+<script defer src="{{ $mhchemJS.RelPermalink }}" integrity="{{ $mhchemJS.Data.Integrity }}"></script>
+{{ $katexFonts := resources.Match "lib/katex/fonts/*" }}
+{{- range $katexFonts -}}
+  {{ .Publish }}
+{{- end -}}
+<script>
+  // TODO: make render options configurable
+  // Reference: https://katex.org/docs/autorender#api
+  document.addEventListener("DOMContentLoaded", function () {
+    renderMathInElement(document.body, {
+      delimiters: [
+        { left: "$$", right: "$$", display: true },
+        { left: "$", right: "$", display: false },
+        { left: "\\(", right: "\\)", display: false },
+        { left: "\\begin{equation}", right: "\\end{equation}", display: true },
+        {left: "\\begin{align}", right: "\\end{align}", display: true},
+        {left: "\\begin{alignat}", right: "\\end{alignat}", display: true},
+        {left: "\\begin{gather}", right: "\\end{gather}", display: true},
+        {left: "\\begin{CD}", right: "\\end{CD}", display: true},
+        { left: "\\[", right: "\\]", display: true },
+      ],
+      throwOnError: false,
     });
-  </script>
-{{ end }}
+  });
+</script>

--- a/layouts/partials/scripts/katex.html
+++ b/layouts/partials/scripts/katex.html
@@ -1,0 +1,35 @@
+{{/* KaTex */}}
+{{- if .Page.Params.math -}}
+  {{- $katexCSS := resources.Get "lib/katex/katex.min.css" | fingerprint -}}
+  {{- $katexJS := resources.Get "lib/katex/katex.min.js" | fingerprint -}}
+  {{- $mhchemJS := resources.Get "lib/katex/mhchem.min.js" | fingerprint -}}
+  {{- $katexAutoRenderJS := resources.Get "lib/katex/auto-render.min.js" | fingerprint -}}
+  <link type="text/css" rel="stylesheet" href="{{ $katexCSS.RelPermalink }}" integrity="{{ $katexCSS.Data.Integrity }}" />
+  <script defer src="{{ $katexJS.RelPermalink }}" integrity="{{ $katexJS.Data.Integrity }}"></script>
+  <script defer src="{{ $katexAutoRenderJS.RelPermalink }}" integrity="{{ $katexAutoRenderJS.Data.Integrity }}"></script>
+  <script defer src="{{ $mhchemJS.RelPermalink }}" integrity="{{ $mhchemJS.Data.Integrity }}"></script>
+  {{ $katexFonts := resources.Match "lib/katex/fonts/*" }}
+  {{- range $katexFonts -}}
+    {{ .Publish }}
+  {{- end -}}
+  <script>
+    // TODO: make render options configurable
+    // Reference: https://katex.org/docs/autorender#api
+    document.addEventListener("DOMContentLoaded", function () {
+      renderMathInElement(document.body, {
+        delimiters: [
+          { left: "$$", right: "$$", display: true },
+          { left: "$", right: "$", display: false },
+          { left: "\\(", right: "\\)", display: false },
+          { left: "\\begin{equation}", right: "\\end{equation}", display: true },
+          {left: "\\begin{align}", right: "\\end{align}", display: true},
+          {left: "\\begin{alignat}", right: "\\end{alignat}", display: true},
+          {left: "\\begin{gather}", right: "\\end{gather}", display: true},
+          {left: "\\begin{CD}", right: "\\end{CD}", display: true},
+          { left: "\\[", right: "\\]", display: true },
+        ],
+        throwOnError: false,
+      });
+    });
+  </script>
+{{ end }}

--- a/layouts/partials/scripts/mermaid.html
+++ b/layouts/partials/scripts/mermaid.html
@@ -1,35 +1,33 @@
 {{/* Mermaid */}}
-{{/* FIXME: need to investigate .Page.Store hasMermaid is set for homepage */}}
-{{- if and (.Page.Store.Get "hasMermaid") (not .Page.IsHome) -}}
-  {{- $mermaidJS := resources.Get "lib/mermaid/mermaid.min.js" | fingerprint -}}
-  <script defer src="{{ $mermaidJS.RelPermalink }}" integrity="{{ $mermaidJS.Data.Integrity }}"></script>
-  <script>
-    document.addEventListener("DOMContentLoaded", () => {
-      // Store original mermaid code for each diagram
-      document.querySelectorAll(".mermaid").forEach(el => {
-        el.dataset.original = el.innerHTML;
-      });
 
-      const theme = document.documentElement.classList.contains("dark") ? "dark" : "default";
-      mermaid.initialize({ startOnLoad: true, theme: theme });
-
-      let timeout;
-      new MutationObserver(() => {
-        clearTimeout(timeout);
-        timeout = setTimeout(() => {
-          const theme = document.documentElement.classList.contains("dark") ? "dark" : "default";
-          document.querySelectorAll(".mermaid").forEach(el => {
-            // Reset to original content, preserving HTML
-            el.innerHTML = el.dataset.original;
-            el.removeAttribute("data-processed");
-          });
-          mermaid.initialize({ startOnLoad: true, theme: theme });
-          mermaid.init();
-        }, 150);
-      }).observe(document.documentElement, {
-        attributes: true,
-        attributeFilter: ["class"]
-      });
+{{- $mermaidJS := resources.Get "lib/mermaid/mermaid.min.js" | fingerprint -}}
+<script defer src="{{ $mermaidJS.RelPermalink }}" integrity="{{ $mermaidJS.Data.Integrity }}"></script>
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    // Store original mermaid code for each diagram
+    document.querySelectorAll(".mermaid").forEach(el => {
+      el.dataset.original = el.innerHTML;
     });
-  </script>
-{{- end -}}
+
+    const theme = document.documentElement.classList.contains("dark") ? "dark" : "default";
+    mermaid.initialize({ startOnLoad: true, theme: theme });
+
+    let timeout;
+    new MutationObserver(() => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        const theme = document.documentElement.classList.contains("dark") ? "dark" : "default";
+        document.querySelectorAll(".mermaid").forEach(el => {
+          // Reset to original content, preserving HTML
+          el.innerHTML = el.dataset.original;
+          el.removeAttribute("data-processed");
+        });
+        mermaid.initialize({ startOnLoad: true, theme: theme });
+        mermaid.init();
+      }, 150);
+    }).observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"]
+    });
+  });
+</script>

--- a/layouts/partials/scripts/mermaid.html
+++ b/layouts/partials/scripts/mermaid.html
@@ -1,0 +1,35 @@
+{{/* Mermaid */}}
+{{/* FIXME: need to investigate .Page.Store hasMermaid is set for homepage */}}
+{{- if and (.Page.Store.Get "hasMermaid") (not .Page.IsHome) -}}
+  {{- $mermaidJS := resources.Get "lib/mermaid/mermaid.min.js" | fingerprint -}}
+  <script defer src="{{ $mermaidJS.RelPermalink }}" integrity="{{ $mermaidJS.Data.Integrity }}"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      // Store original mermaid code for each diagram
+      document.querySelectorAll(".mermaid").forEach(el => {
+        el.dataset.original = el.innerHTML;
+      });
+
+      const theme = document.documentElement.classList.contains("dark") ? "dark" : "default";
+      mermaid.initialize({ startOnLoad: true, theme: theme });
+
+      let timeout;
+      new MutationObserver(() => {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => {
+          const theme = document.documentElement.classList.contains("dark") ? "dark" : "default";
+          document.querySelectorAll(".mermaid").forEach(el => {
+            // Reset to original content, preserving HTML
+            el.innerHTML = el.dataset.original;
+            el.removeAttribute("data-processed");
+          });
+          mermaid.initialize({ startOnLoad: true, theme: theme });
+          mermaid.init();
+        }, 150);
+      }).observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class"]
+      });
+    });
+  </script>
+{{- end -}}

--- a/layouts/partials/scripts/search.html
+++ b/layouts/partials/scripts/search.html
@@ -1,0 +1,16 @@
+{{/* Search */}}
+{{- if (site.Params.search.enable | default true) -}}
+  {{- $searchType := site.Params.search.type | default "flexsearch" -}}
+  {{- if eq $searchType "flexsearch" -}}
+    {{- $jsSearchScript := printf "%s.search.js" .Language.Lang -}}
+    {{- $jsSearch := resources.Get "js/flexsearch.js" | resources.ExecuteAsTemplate $jsSearchScript . -}}
+    {{- if hugo.IsProduction -}}
+      {{- $jsSearch = $jsSearch | minify | fingerprint -}}
+    {{- end -}}
+    {{- $flexSearchJS := resources.Get "lib/flexsearch/flexsearch.bundle.min.js" | fingerprint -}}
+    <script defer src="{{ $flexSearchJS.RelPermalink }}" integrity="{{ $flexSearchJS.Data.Integrity }}"></script>
+    <script defer src="{{ $jsSearch.RelPermalink }}" integrity="{{ $jsSearch.Data.Integrity }}"></script>
+  {{- else -}}
+    {{- warnf `search type "%s" is not supported` $searchType -}}
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
This pull request refactors the `layouts/partials/scripts.html` file by moving the script configurations to separate partial files for better modularity and maintainability. The changes include creating new partial files for core scripts, search, Mermaid, and KaTex functionalities.

Refactoring scripts into partial files:

* [`layouts/partials/scripts.html`](diffhunk://#diff-ed3b5a25a9efb89d0cebc442bd8b68c2b2caa45746f6633f89aa4a0e45410f9aL1-L104): Removed inline script configurations and replaced them with calls to newly created partial files.
* [`layouts/partials/scripts/core.html`](diffhunk://#diff-82ead61dd9d44a8d2748e8983dbd7090690826ed0d27ed7f97395a074a007688R1-R14): Added core script configurations including theme, menu, tabs, language, code copy, file tree, sidebar, and back-to-top scripts.
* [`layouts/partials/scripts/search.html`](diffhunk://#diff-8c63062a73463305c4fbdc01b6481cd513055198b8ce5d2bc64cf6f93456c141R1-R16): Added search script configurations supporting FlexSearch.
* [`layouts/partials/scripts/mermaid.html`](diffhunk://#diff-04f0355def121bbd653248a001d168be2b8eb2109bba43089d62d8073c4f1bd1R1-R33): Added Mermaid script configurations for rendering diagrams with theme switching support.
* [`layouts/partials/scripts/katex.html`](diffhunk://#diff-eb9e4a8c8bef2918923a744ee315a46263dd593987de37ccb20f7682931c91f1R1-R33): Added KaTex script configurations for rendering mathematical expressions with various delimiters.