### PR TITLE
feat: add optional pagination control for blog articles

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -163,6 +163,9 @@ params:
       # date | lastmod | publishDate | title | weight
       sortBy: date
       sortOrder: desc # or "asc"
+    
+    article:
+      displayPagination: true
 
   highlight:
     copy:

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -38,10 +38,12 @@
         <div class="content">
           {{ .Content }}
         </div>
-        {{ partial "components/last-updated.html" . }}
-        {{ .Scratch.Set "reversePagination" true }}
-        {{ partial "components/pager.html" . }}
-        {{ partial "components/comments.html" . }}
+        {{- partial "components/last-updated.html" . -}}
+        {{- if (site.Params.blog.article.displayPagination | default true) -}}
+          {{- .Scratch.Set "reversePagination" true -}}
+          {{- partial "components/pager.html" . -}}
+        {{ end }}
+        {{- partial "components/comments.html" . -}}
       </main>
     </article>
   </div>


### PR DESCRIPTION
This pull request introduces changes to the pagination settings and the layout of the blog articles. The key changes include adding a new configuration for displaying pagination and updating the blog article layout to respect this configuration.

Configuration changes:

* [`exampleSite/hugo.yaml`](diffhunk://#diff-6052113475ce5476ec9e005d96a9de8d43c9031259e77d35d3dcee30117474c1R167-R169): Added a new `article` section with a `displayPagination` parameter to control the pagination display in blog articles.

Layout changes:

* [`layouts/blog/single.html`](diffhunk://#diff-5942e866d871d1df37aadd5f735f37d2708ea0c3ebc753ccd1cc38a71a68e19bL41-R46): Updated the layout to conditionally display pagination based on the new `displayPagination` parameter in the configuration.