### PR TITLE
fix: sanitize heading title to prevent html tags displayed on mobile

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -126,7 +126,7 @@
                 href="#{{ anchorize .ID }}"
                 class="hx-flex hx-rounded hx-px-2 hx-py-1.5 hx-text-sm hx-transition-colors [word-break:break-word] hx-cursor-pointer [-webkit-tap-highlight-color:transparent] [-webkit-touch-callout:none] contrast-more:hx-border hx-gap-2 before:hx-opacity-25 before:hx-content-['#'] hx-text-gray-500 hover:hx-bg-gray-100 hover:hx-text-gray-900 dark:hx-text-neutral-400 dark:hover:hx-bg-primary-100/5 dark:hover:hx-text-gray-50 contrast-more:hx-text-gray-900 contrast-more:dark:hx-text-gray-50 contrast-more:hx-border-transparent contrast-more:hover:hx-border-gray-900 contrast-more:dark:hover:hx-border-gray-50"
               >
-                {{- .Title -}}
+                {{- .Title | safeHTML | plainify | htmlUnescape -}}
               </a>
             </li>
           {{ end -}}


### PR DESCRIPTION
This pull request includes a small but important change to the `layouts/partials/sidebar.html` file. The change enhances the way titles are processed and displayed in the sidebar by adding additional filters to ensure the HTML is safe and properly unescaped.

* [`layouts/partials/sidebar.html`](diffhunk://#diff-21c3ed4170b0e684f5c718a8b3bb28e73bb15d61a3f0f2301cafcc62ca5034f3L129-R129): Modified the title rendering to use `safeHTML`, `plainify`, and `htmlUnescape` filters for better handling of HTML content.