### PR TITLE
fix: sidebar more menu item link with multilingual

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -144,14 +144,13 @@
         <span class="hx-cursor-default">{{ $name }}</span>
       </li>
     {{ else }}
-        {{- $newURL := .URL -}}
-        {{- with .PageRef -}}
-          {{- if hasPrefix . "/" -}}
-            {{/* {{- $link = relLangURL (strings.TrimPrefix "/" .) -}} */}}
-            {{ $newURL = relLangURL (strings.TrimPrefix "/" .) }}
-          {{- end -}}
+      {{- $link := .URL -}}
+      {{- with .PageRef -}}
+        {{- if hasPrefix . "/" -}}
+          {{- $link = relLangURL (strings.TrimPrefix "/" .) -}}
         {{- end -}}
-      <li>{{ template "sidebar-item-link" dict "active" false "title" $name "link" $newURL }}</li>
+      {{- end -}}
+      <li>{{ template "sidebar-item-link" dict "active" false "title" $name "link" $link }}</li>
     {{ end }}
   {{- end -}}
 {{- end -}}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -144,7 +144,14 @@
         <span class="hx-cursor-default">{{ $name }}</span>
       </li>
     {{ else }}
-      <li>{{ template "sidebar-item-link" dict "active" false "title" $name "link" (.URL | relLangURL) }}</li>
+        {{- $newURL := .URL -}}
+        {{- with .PageRef -}}
+          {{- if hasPrefix . "/" -}}
+            {{/* {{- $link = relLangURL (strings.TrimPrefix "/" .) -}} */}}
+            {{ $newURL = relLangURL (strings.TrimPrefix "/" .) }}
+          {{- end -}}
+        {{- end -}}
+      <li>{{ template "sidebar-item-link" dict "active" false "title" $name "link" $newURL }}</li>
     {{ end }}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Fixes #593

Correctly parses multilingual URL in sidebar, particularly if lang code follows a nested sub directory.

For instance, GH pages hosting where the baseurl might be of the format `https://<USERNAME>.github.io/<REPO>/`.

This uses the same method the main navbar does for parsing correct lang in URL.
https://github.com/imfing/hextra/blob/662d9202dcca74d66373ac1d1c9071c6ee2533a5/layouts/partials/navbar.html#L37-L40