### PR TITLE
fix: copy-button not being rendered in details blocks

### DIFF
--- a/layouts/partials/components/codeblock.html
+++ b/layouts/partials/components/codeblock.html
@@ -25,5 +25,5 @@
 {{- if transform.CanHighlight $lang -}}
   <div>{{- highlight $content $lang $options -}}</div>
 {{- else -}}
-  <pre><code>{{ $content }}</code></pre>
+  <div><pre><code>{{ $content }}</code></pre></div>
 {{- end -}}


### PR DESCRIPTION
After looking at the source for the codeblock shortcode and my rendered page, I could only observe this div as difference.
To my own surprise, adding it fixes #605 