### PR TITLE
fix: use InnerDeindent for filetree shortcode rendering

### DIFF
--- a/layouts/shortcodes/filetree/container.html
+++ b/layouts/shortcodes/filetree/container.html
@@ -1,5 +1,5 @@
 <div class="hextra-filetree hx-mt-6 hx-select-none hx-text-sm hx-text-gray-800 dark:hx-text-gray-300 not-prose">
   <div class="hx-inline-block hx-rounded-lg hx-border hx-px-4 hx-py-2 dark:hx-border-neutral-800">
-    {{- .Inner -}}
+    {{- .InnerDeindent -}}
   </div>
 </div>

--- a/layouts/shortcodes/filetree/folder.html
+++ b/layouts/shortcodes/filetree/folder.html
@@ -12,6 +12,6 @@
     <span class="ltr:hx-ml-1 rtl:hx-mr-1">{{ $name }}</span>
   </button>
   <ul data-state="{{ $state }}" class="ltr:hx-pl-5 rtl:hx-pr-5 data-[state=closed]:hx-hidden">
-    {{- .Inner -}}
+    {{- .InnerDeindent -}}
   </ul>
 </li>


### PR DESCRIPTION
fixes #611 