### PR TITLE
fix: KaTeX fonts are not fetched from CDN

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -63,12 +63,17 @@
   {{ $noop := .WordCount -}}
   {{ if .Page.Store.Get "hasMath" -}}
     <!-- TODO: make url configurable -->
-    {{ $katexCssUrl := printf "https://cdn.jsdelivr.net/npm/katex@latest/dist/katex%s.css" (cond hugo.IsProduction ".min" "") -}}
+    {{ $katexBaseUrl := "https://cdn.jsdelivr.net/npm/katex@latest/dist" }} 
+    {{ $katexCssUrl := printf "%s/katex%s.css" $katexBaseUrl (cond hugo.IsProduction ".min" "") -}}
+    {{ $katexFontPattern := "url(fonts/" }}
+    {{ $katexFontSubstituted := printf "url(%s/fonts/" $katexBaseUrl }}
+  
     {{ with try (resources.GetRemote $katexCssUrl) -}}
       {{ with .Err -}}
         {{ errorf "Could not retrieve KaTeX css file from %s. Reason: %s." $katexCssUrl . -}}
       {{ else with.Value -}}
-        {{ with resources.Copy (printf "css/katex%s.css" (cond hugo.IsProduction ".min" "")) . -}}
+        {{ $katexCssContent := strings.Replace .Content $katexFontPattern $katexFontSubstituted }}
+        {{ with resources.FromString (printf "css/katex%s.css" (cond hugo.IsProduction ".min" "")) $katexCssContent -}}
           <link rel="stylesheet" href="{{- .RelPermalink -}}" integrity="{{- . | fingerprint -}}" crossorigin="anonymous" />
         {{ end -}}
       {{ end -}}


### PR DESCRIPTION
Currently, the KaTeX CSS file `katex(\.min)?.css` is retrieve from CDN, whose content is not patched:

```css
@font-face {
    font-family: KaTeX_AMS;
    font-style: normal;
    font-weight: 400;
    src: url(fonts/KaTeX_AMS-Regular.woff2) format("woff2"),url(fonts/KaTeX_AMS-Regular.woff) format("woff"),url(fonts/KaTeX_AMS-Regular.ttf) format("truetype")
}

// ...
```

On line 5, for example, `fonts/KaTeX_AMS-Regular.woff2` is expanded to `<my-website>/css/fonts/KaTeX_AMS-Regular.woff2`, which is a nonexistent path in the docs website. This PR adds codes to replace these URLs with CDN's paths.

Fix #655.