### PR TITLE
feat: make image render hook aware of assets directory

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,27 +1,43 @@
 {{- $alt := .PlainText | safeHTML -}}
 {{- $lazyLoading := .Page.Site.Params.enableImageLazyLoading | default true -}}
 {{- $dest := .Destination -}}
+{{- $url := urls.Parse $dest -}}
 
-{{- $isLocal := not (urls.Parse $dest).Scheme -}}
+{{- $isLocal := not $url.Scheme -}}
 {{- $isPage := and (eq .Page.Kind "page") (not .Page.BundleType) -}}
 {{- $startsWithSlash := hasPrefix $dest "/" -}}
 {{- $startsWithRelative := hasPrefix $dest "../" -}}
 
 {{- if and $dest $isLocal -}}
   {{- if $startsWithSlash -}}
-    {{/* Images under static directory */}}
-    {{- $dest = (relURL (strings.TrimPrefix "/" $dest)) -}}
+    {{- with or (.PageInner.Resources.Get $url.Path) (resources.Get $url.Path) -}}
+      {{/* Images under assets directory */}}
+      {{- $query := cond $url.RawQuery (printf "?%s" $url.RawQuery) "" -}}
+      {{- $fragment := cond $url.Fragment (printf "?%s" $url.Fragment) "" -}}
+      {{- $dest = printf "%s%s%s" .RelPermalink $query $fragment -}}
+    {{- else -}}
+      {{/* Images under static directory */}}
+      {{- $dest = (relURL (strings.TrimPrefix "/" $dest)) -}}
+    {{- end -}}
   {{- else if and $isPage (not $startsWithRelative) -}}
     {{/* Images that are sibling to the individual page file */}}
     {{ $dest = (printf "../%s" $dest) }}
   {{- end -}}
 {{- end -}}
 
+{{- $attributes := "" -}}
+{{- range $key, $value := .Attributes -}}
+  {{- if $value -}}
+    {{- $pair := printf "%s=%q" $key ($value | transform.HTMLEscape) -}}
+    {{- $attributes = printf "%s %s" $attributes $pair -}}
+  {{- end -}}
+{{- end -}}
+
 {{- with .Title -}}
   <figure>
-    <img src="{{ $dest | safeURL }}" title="{{ . }}" alt="{{ $alt }}" {{ if $lazyLoading }}loading="lazy"{{ end }} />
+    <img src="{{ $dest | safeURL }}" title="{{ . }}" alt="{{ $alt }}" {{ $attributes | safeHTMLAttr }} {{ if $lazyLoading }}loading="lazy"{{ end }} />
     <figcaption>{{ . }}</figcaption>
   </figure>
 {{- else -}}
-  <img src="{{ $dest | safeURL }}" alt="{{ $alt }}" {{ if $lazyLoading }}loading="lazy"{{ end }} />
+  <img src="{{ $dest | safeURL }}" alt="{{ $alt }}" {{ $attributes | safeHTMLAttr }} {{ if $lazyLoading }}loading="lazy"{{ end }} />
 {{- end -}}


### PR DESCRIPTION
The image render hooks resolves image URLs in Markdown. So far the implementation in this theme simply assumes that those images are placed in `/static` or relative to the referencing page, while those in `/assets` are ignored. Because Hugo lazily copies files in `/assets` only when they are explicitly referenced (such as shortcodes), images located in `/assets` and dependent on pages using  `![...](...)` syntax will not be published, and the corresponding links will actually point to nothing.

This PR updates the hook, which now first tries to resolve a image whose link starts with `/` to a global resource (i.e. `/assets`), and fallbacks to `/static` when the image doesn't exist in `/assets`.

In addition, when the [markdown attributes](https://gohugo.io/content-management/markdown-attributes/) feature is enabled, attributes like `{.class #id}` should be preserved if exists. This PR also adds this functionality to make markdown attributes work with the image render hook.