### PR TITLE
fix: link render hook produces dangling links when base URL has additional segments

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -13,7 +13,7 @@
     {{- with or (.PageInner.Resources.Get $url.Path) (resources.Get $url.Path) -}}
       {{/* Images under assets directory */}}
       {{- $query := cond $url.RawQuery (printf "?%s" $url.RawQuery) "" -}}
-      {{- $fragment := cond $url.Fragment (printf "?%s" $url.Fragment) "" -}}
+      {{- $fragment := cond $url.Fragment (printf "#%s" $url.Fragment) "" -}}
       {{- $dest = printf "%s%s%s" .RelPermalink $query $fragment -}}
     {{- else -}}
       {{/* Images under static directory */}}

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,3 +1,16 @@
+{{- $dest := .Destination -}}
+{{- $url := urls.Parse $dest -}}
+
+{{- if and $dest (hasPrefix $dest "/") -}}
+  {{- with or (.PageInner.GetPage $url.Path) (.PageInner.Resources.Get $url.Path) (resources.Get $url.Path) -}}
+    {{- $query := cond $url.RawQuery (printf "?%s" $url.RawQuery) "" -}}
+    {{- $fragment := cond $url.Fragment (printf "#%s" $url.Fragment) "" -}}
+    {{- $dest = printf "%s%s%s" .RelPermalink $query $fragment -}}
+  {{- else -}}
+    {{- $dest = (relURL (strings.TrimPrefix "/" $dest)) -}}
+  {{- end -}}
+{{- end -}}
+    
 {{- with . -}}
-  <a href="{{ .Destination | safeURL }}" {{ with .Title }}title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }}target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>
+  <a href="{{ $dest | safeURL }}" {{ with .Title }}title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }}target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>
 {{- end -}}


### PR DESCRIPTION
When the website is configured with `baseURL = "https://example.com/sub-website/"`, the current link render hook will turn `[](/some/link)` to `<a href="https://example.com/some/link"></a>` rather than `<a href="https://example.com/sub-website/some/link"></a>`. A real-world example is [the theme's documentation website](http://imfing.github.io/hextra/docs/guide/configuration/), where a link with a title of `Organize File` will be redirected to the 404 page. This PR fixes this problem. Note that merging this will introduce a breaking change, but I personally think that this makes sense, in that the Hextra theme haven't published a major release ever since.

By the way, in my last PR #657, I mistakenly used `?` for URL fragments. The fix is rather apparent, which is only a one-character substitution, so I put it along with this PR for convenience and simplicity. Apology for my carelessness.