### PR TITLE
Update deploy guides to Hugo 0.147.7

### DIFF
--- a/exampleSite/content/docs/guide/deploy-site.ja.md
+++ b/exampleSite/content/docs/guide/deploy-site.ja.md
@@ -54,7 +54,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.145.0
+      HUGO_VERSION: 0.147.7
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -146,7 +146,7 @@ run: |
 3. [hextra-starter-template][hextra-starter-template]を使用していない場合、以下の設定を手動で行います：
    - ビルドコマンドを `hugo --gc --minify` に設定します。
    - 公開ディレクトリを `public` に指定します。
-   - 環境変数 `HUGO_VERSION` を追加し、`0.145.0` に設定するか、`netlify.toml` ファイルに設定します。
+   - 環境変数 `HUGO_VERSION` を追加し、`0.147.7` に設定するか、`netlify.toml` ファイルに設定します。
 4. デプロイします！
 
 詳細については、[NetlifyでのHugo](https://docs.netlify.com/integrations/frameworks/hugo/)を確認してください。

--- a/exampleSite/content/docs/guide/deploy-site.md
+++ b/exampleSite/content/docs/guide/deploy-site.md
@@ -54,7 +54,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.145.0
+      HUGO_VERSION: 0.147.7
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -146,7 +146,7 @@ For more details, check out:
 3. If you are not using [hextra-starter-template][hextra-starter-template], configure the following manually:
    - Configure the Build command to `hugo --gc --minify`
    - Specify the Publish directory to `public`
-   - Add Environment variable `HUGO_VERSION` and set to `0.145.0`, or alternatively, set it in `netlify.toml` file
+   - Add Environment variable `HUGO_VERSION` and set to `0.147.7`, or alternatively, set it in `netlify.toml` file
 4. Deploy!
 
 Check [Hugo on Netlify](https://docs.netlify.com/integrations/frameworks/hugo/) for more details.

--- a/exampleSite/content/docs/guide/deploy-site.zh-cn.md
+++ b/exampleSite/content/docs/guide/deploy-site.zh-cn.md
@@ -54,7 +54,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.145.0
+      HUGO_VERSION: 0.147.7
     steps:
       - name: 检出
         uses: actions/checkout@v4
@@ -146,7 +146,7 @@ run: |
 3. 如果您没有使用 [hextra-starter-template][hextra-starter-template]，请手动配置以下内容：
    - 将构建命令配置为 `hugo --gc --minify`
    - 指定发布目录为 `public`
-   - 添加环境变量 `HUGO_VERSION` 并设置为 `0.145.0`，或者将其设置在 `netlify.toml` 文件中
+   - 添加环境变量 `HUGO_VERSION` 并设置为 `0.147.7`，或者将其设置在 `netlify.toml` 文件中
 4. 部署！
 
 查看 [Netlify 上的 Hugo](https://docs.netlify.com/integrations/frameworks/hugo/) 了解更多详情。


### PR DESCRIPTION
## Summary
- update Hugo version in deploy-site docs to 0.147.7

## Testing
- `npm test` *(fails: Missing script)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f86b0aca4832899c11f35ad06e994