### PR TITLE
fix: wrong SRI hash for katex.css

### DIFF
--- a/dev.toml
+++ b/dev.toml
@@ -1,5 +1,5 @@
 # Theme development config for exampleSite
-# https://gohugo.io/getting-started/configuration/#configure-cache-busters
+# https://gohugo.io/configuration/build/#cache-busters
 [build]
   [build.buildStats]
     enable = true

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -95,10 +95,11 @@
     {{ with try (resources.GetRemote $katexCssUrl) -}}
       {{ with .Err -}}
         {{ errorf "Could not retrieve KaTeX css file from %s. Reason: %s." $katexCssUrl . -}}
-      {{ else with.Value -}}
+      {{ else with .Value -}}
         {{ $katexCssContent := strings.Replace .Content $katexFontPattern $katexFontSubstituted }}
         {{ with resources.FromString (printf "css/katex%s.css" (cond hugo.IsProduction ".min" "")) $katexCssContent -}}
-          <link rel="stylesheet" href="{{- .RelPermalink -}}" integrity="{{- . | fingerprint -}}" crossorigin="anonymous" />
+          {{ $cssHash := . | fingerprint "sha512" -}}
+          <link rel="stylesheet" href="{{- .RelPermalink -}}" integrity="{{- $cssHash.Data.Integrity -}}" crossorigin="anonymous" />
         {{ end -}}
       {{ end -}}
     {{ end -}}


### PR DESCRIPTION
Currently, an invalid/wrong SRI hash is listed for `katex.css`.

````
<link rel="stylesheet" href="/css/katex.css" integrity="/css/katex.css" crossorigin="anonymous" />
````

This PR fixes that issue.
It also corrects an outdated link I spotted.