### PR TITLE
fix: spacing between title and site title

### DIFF
--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -12,7 +12,7 @@
     {{- if .IsHome -}}
       {{ .Site.Title -}}
     {{ else -}}
-      {{ with .Title }}{{ . }} –{{ end -}}
+      {{ with .Title }}{{ . }} – {{ end -}}
       {{ .Site.Title -}}
     {{ end -}}
   </title>


### PR DESCRIPTION
Add a space between the dash and site title in `head.html` to fix spacing.

Space was removed around two weeks ago in commit befce4cd9aaa35d98f23b986ba11ff35fa9b91a4 - [link to file diff](https://github.com/imfing/hextra/commit/befce4cd9aaa35d98f23b986ba11ff35fa9b91a4#diff-96dd75a968976edd5e03170268ed9085733f75c3fb24f992ae613c89e6de42dcL15).