### PR TITLE
fix: tab not switching on non-synced mode

### DIFF
--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -26,10 +26,13 @@
   const groups = document.querySelectorAll('[data-tab-group]');
 
   groups.forEach((group) => {
-    const key = encodeURIComponent(group.dataset.tabGroup);
-    const saved = localStorage.getItem('hextra-tab-' + key);
-    if (saved !== null) {
-      updateGroup(group, parseInt(saved, 10));
+    const isSync = group.dataset.tabSync === 'true';
+    if (isSync) {
+      const key = encodeURIComponent(group.dataset.tabGroup);
+      const saved = localStorage.getItem('hextra-tab-' + key);
+      if (saved !== null) {
+        updateGroup(group, parseInt(saved, 10));
+      }
     }
   });
 
@@ -40,11 +43,19 @@
         e.target
       );
       const key = encodeURIComponent(container.dataset.tabGroup);
-      document
-        .querySelectorAll('[data-tab-group="' + container.dataset.tabGroup + '"]')
-        .forEach((grp) => updateGroup(grp, index));
-      if (key) {
-        localStorage.setItem('hextra-tab-' + key, index.toString());
+      const isSync = container.dataset.tabSync === 'true';
+      
+      if (isSync) {
+        // Sync behavior: update all tab groups with the same name
+        document
+          .querySelectorAll('[data-tab-group="' + container.dataset.tabGroup + '"]')
+          .forEach((grp) => updateGroup(grp, index));
+        if (key) {
+          localStorage.setItem('hextra-tab-' + key, index.toString());
+        }
+      } else {
+        // Non-sync behavior: update only this specific tab group
+        updateGroup(container, index);
       }
     });
   });

--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -26,9 +26,10 @@
   const groups = document.querySelectorAll('[data-tab-group]');
 
   groups.forEach((group) => {
-    const isSync = group.dataset.tabSync === 'true';
+    const tabGroupValue = group.dataset.tabGroup;
+    const isSync = tabGroupValue && tabGroupValue.includes(',');
     if (isSync) {
-      const key = encodeURIComponent(group.dataset.tabGroup);
+      const key = encodeURIComponent(tabGroupValue);
       const saved = localStorage.getItem('hextra-tab-' + key);
       if (saved !== null) {
         updateGroup(group, parseInt(saved, 10));
@@ -42,13 +43,14 @@
       const index = Array.from(container.querySelectorAll('.hextra-tabs-toggle')).indexOf(
         e.target
       );
-      const key = encodeURIComponent(container.dataset.tabGroup);
-      const isSync = container.dataset.tabSync === 'true';
+      const tabGroupValue = container.dataset.tabGroup;
+      const key = encodeURIComponent(tabGroupValue);
+      const isSync = tabGroupValue && tabGroupValue.includes(',');
       
       if (isSync) {
         // Sync behavior: update all tab groups with the same name
         document
-          .querySelectorAll('[data-tab-group="' + container.dataset.tabGroup + '"]')
+          .querySelectorAll('[data-tab-group="' + tabGroupValue + '"]')
           .forEach((grp) => updateGroup(grp, index));
         if (key) {
           localStorage.setItem('hextra-tab-' + key, index.toString());

--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -23,17 +23,13 @@
     });
   }
 
-  const groups = document.querySelectorAll('[data-tab-group]');
+  const syncGroups = document.querySelectorAll('[data-tab-group]');
 
-  groups.forEach((group) => {
-    const tabGroupValue = group.dataset.tabGroup;
-    const isSync = tabGroupValue && tabGroupValue.includes(',');
-    if (isSync) {
-      const key = encodeURIComponent(tabGroupValue);
-      const saved = localStorage.getItem('hextra-tab-' + key);
-      if (saved !== null) {
-        updateGroup(group, parseInt(saved, 10));
-      }
+  syncGroups.forEach((group) => {
+    const key = encodeURIComponent(group.dataset.tabGroup);
+    const saved = localStorage.getItem('hextra-tab-' + key);
+    if (saved !== null) {
+      updateGroup(group, parseInt(saved, 10));
     }
   });
 
@@ -43,18 +39,15 @@
       const index = Array.from(container.querySelectorAll('.hextra-tabs-toggle')).indexOf(
         e.target
       );
-      const tabGroupValue = container.dataset.tabGroup;
-      const key = encodeURIComponent(tabGroupValue);
-      const isSync = tabGroupValue && tabGroupValue.includes(',');
       
-      if (isSync) {
+      if (container.dataset.tabGroup) {
         // Sync behavior: update all tab groups with the same name
+        const tabGroupValue = container.dataset.tabGroup;
+        const key = encodeURIComponent(tabGroupValue);
         document
           .querySelectorAll('[data-tab-group="' + tabGroupValue + '"]')
           .forEach((grp) => updateGroup(grp, index));
-        if (key) {
-          localStorage.setItem('hextra-tab-' + key, index.toString());
-        }
+        localStorage.setItem('hextra-tab-' + key, index.toString());
       } else {
         // Non-sync behavior: update only this specific tab group
         updateGroup(container, index);

--- a/layouts/_shortcodes/tabs.html
+++ b/layouts/_shortcodes/tabs.html
@@ -2,7 +2,6 @@
 {{- $defaultIndex := int ((.Get "defaultIndex") | default "0") -}}
 
 {{- $enableSync := site.Params.page.tabs.sync | default false -}}
-{{- $tabGroupId := printf "%s-%d" (delimit $items ",") now.UnixNano -}}
 
 {{- if not (.Get "items") -}}
   {{ errorf "tabs shortcode: 'items' parameter is required" }}
@@ -19,7 +18,7 @@
 {{- end -}}
 
 <div class="hextra-scrollbar hx:overflow-x-auto hx:overflow-y-hidden hx:overscroll-x-contain">
-  <div class="hx:mt-4 hx:flex hx:w-max hx:min-w-full hx:border-b hx:border-gray-200 hx:pb-px hx:dark:border-neutral-800" data-tab-group="{{ if $enableSync }}{{ delimit $items `,` }}{{ else }}{{ $tabGroupId }}{{ end }}">
+  <div class="hx:mt-4 hx:flex hx:w-max hx:min-w-full hx:border-b hx:border-gray-200 hx:pb-px hx:dark:border-neutral-800"{{ if $enableSync }} data-tab-group="{{ delimit $items `,` }}"{{ end }}>
     {{- range $i, $item := $items -}}
       <button
         class="hextra-tabs-toggle hx:cursor-pointer hx:data-[state=selected]:border-primary-500 hx:data-[state=selected]:text-primary-600 hx:data-[state=selected]:dark:border-primary-500 hx:data-[state=selected]:dark:text-primary-600 hx:mr-2 hx:rounded-t hx:p-2 hx:font-medium hx:leading-5 hx:transition-colors hx:-mb-0.5 hx:select-none hx:border-b-2 hx:border-transparent hx:text-gray-600 hx:hover:border-gray-200 hx:hover:text-black hx:dark:text-gray-200 hx:dark:hover:border-neutral-800 hx:dark:hover:text-white"

--- a/layouts/_shortcodes/tabs.html
+++ b/layouts/_shortcodes/tabs.html
@@ -2,6 +2,7 @@
 {{- $defaultIndex := int ((.Get "defaultIndex") | default "0") -}}
 
 {{- $enableSync := site.Params.page.tabs.sync | default false -}}
+{{- $tabGroupId := printf "%s-%d" (delimit $items ",") now.UnixNano -}}
 
 {{- if not (.Get "items") -}}
   {{ errorf "tabs shortcode: 'items' parameter is required" }}
@@ -18,7 +19,7 @@
 {{- end -}}
 
 <div class="hextra-scrollbar hx:overflow-x-auto hx:overflow-y-hidden hx:overscroll-x-contain">
-  <div class="hx:mt-4 hx:flex hx:w-max hx:min-w-full hx:border-b hx:border-gray-200 hx:pb-px hx:dark:border-neutral-800"{{ if $enableSync }} data-tab-group="{{ delimit $items `,` }}"{{ end }}>
+  <div class="hx:mt-4 hx:flex hx:w-max hx:min-w-full hx:border-b hx:border-gray-200 hx:pb-px hx:dark:border-neutral-800" data-tab-group="{{ if $enableSync }}{{ delimit $items `,` }}{{ else }}{{ $tabGroupId }}{{ end }}" data-tab-sync="{{ $enableSync }}">
     {{- range $i, $item := $items -}}
       <button
         class="hextra-tabs-toggle hx:cursor-pointer hx:data-[state=selected]:border-primary-500 hx:data-[state=selected]:text-primary-600 hx:data-[state=selected]:dark:border-primary-500 hx:data-[state=selected]:dark:text-primary-600 hx:mr-2 hx:rounded-t hx:p-2 hx:font-medium hx:leading-5 hx:transition-colors hx:-mb-0.5 hx:select-none hx:border-b-2 hx:border-transparent hx:text-gray-600 hx:hover:border-gray-200 hx:hover:text-black hx:dark:text-gray-200 hx:dark:hover:border-neutral-800 hx:dark:hover:text-white"

--- a/layouts/_shortcodes/tabs.html
+++ b/layouts/_shortcodes/tabs.html
@@ -19,7 +19,7 @@
 {{- end -}}
 
 <div class="hextra-scrollbar hx:overflow-x-auto hx:overflow-y-hidden hx:overscroll-x-contain">
-  <div class="hx:mt-4 hx:flex hx:w-max hx:min-w-full hx:border-b hx:border-gray-200 hx:pb-px hx:dark:border-neutral-800" data-tab-group="{{ if $enableSync }}{{ delimit $items `,` }}{{ else }}{{ $tabGroupId }}{{ end }}" data-tab-sync="{{ $enableSync }}">
+  <div class="hx:mt-4 hx:flex hx:w-max hx:min-w-full hx:border-b hx:border-gray-200 hx:pb-px hx:dark:border-neutral-800" data-tab-group="{{ if $enableSync }}{{ delimit $items `,` }}{{ else }}{{ $tabGroupId }}{{ end }}">
     {{- range $i, $item := $items -}}
       <button
         class="hextra-tabs-toggle hx:cursor-pointer hx:data-[state=selected]:border-primary-500 hx:data-[state=selected]:text-primary-600 hx:data-[state=selected]:dark:border-primary-500 hx:data-[state=selected]:dark:text-primary-600 hx:mr-2 hx:rounded-t hx:p-2 hx:font-medium hx:leading-5 hx:transition-colors hx:-mb-0.5 hx:select-none hx:border-b-2 hx:border-transparent hx:text-gray-600 hx:hover:border-gray-200 hx:hover:text-black hx:dark:text-gray-200 hx:dark:hover:border-neutral-800 hx:dark:hover:text-white"


### PR DESCRIPTION
Problem: Tabs only worked when `page.tabs.sync`: true was configured because the JavaScript relied on the `data-tab-group` attribute, which was only added when sync was enabled.

Modified the tabs shortcode and JavaScript to work in both synced and non-synced modes