### PR TITLE
fix(search): unescape title

### DIFF
--- a/layouts/_partials/utils/extract-headings.html
+++ b/layouts/_partials/utils/extract-headings.html
@@ -20,7 +20,7 @@ The scratchpad must be initialized with empty slices before calling this functio
     {{- $.scratch.Add "keys" (slice $key) -}}
   {{- end -}}
 
-  {{- $title := (printf "<h%d>%s" $heading.Level $heading.Title) -}}
+  {{- $title := (printf "<h%d>%s" $heading.Level $heading.Title) | htmlUnescape -}}
   {{- $.scratch.Add "titles" (slice $title) -}}
 
   {{- partial "utils/extract-headings.html" (dict


### PR DESCRIPTION
Inside the search, the content is unescaped then the title must also be unescaped.

Currently, the title parsed value is:
```
it doesn&rsquo;t work
```

But the content is:
```
it doesn’t work
```
