### PR TITLE
feat: support breadcrumbs for single pages that are neither docs or blogs

### DIFF
--- a/layouts/single.html
+++ b/layouts/single.html
@@ -4,6 +4,7 @@
     {{ partial "toc.html" . }}
     <article class="hx:w-full hx:break-words hx:flex hx:min-h-[calc(100vh-var(--navbar-height))] hx:min-w-0 hx:justify-center hx:pb-8 hx:pr-[calc(env(safe-area-inset-right)-1.5rem)]">
       <main class="hx:w-full hx:min-w-0 hx:max-w-6xl hx:px-6 hx:pt-4 hx:md:px-12">
+        {{ partial "breadcrumb.html" . }}
         <br class="hx:mt-1.5 hx:text-sm" />
         {{ if .Title }}<h1 class="hx:text-center hx:mt-2 hx:text-4xl hx:font-bold hx:tracking-tight hx:text-slate-900 hx:dark:text-slate-100">{{ .Title }}</h1>{{ end }}
         <div class="hx:mb-16"></div>


### PR DESCRIPTION
BREAKING CHANGE: since `layouts/_partials/breadcumb.html` will enable breadcrumbs by default, this is a breaking change. Sites that have pages that use `layouts/single.html` will get breadcrumbs by default on their pages with this change. They can disable the breadcrumbs with frontmatter, however.