### PR TITLE
fix: disable nav tag for toc when toc is disabled

### DIFF
--- a/layouts/_partials/toc.html
+++ b/layouts/_partials/toc.html
@@ -6,8 +6,8 @@
 {{- $editThisPage := (T "editThisPage") | default "Edit this page"}}
 {{- $backToTop := (T "backToTop") | default "Scroll to top" -}}
 
-<nav class="hextra-toc hx:order-last hx:hidden hx:w-64 hx:shrink-0 hx:xl:block hx:print:hidden hx:px-4" aria-label="table of contents">
-  {{- if $toc }}
+{{- if $toc }}
+  <nav class="hextra-toc hx:order-last hx:hidden hx:w-64 hx:shrink-0 hx:xl:block hx:print:hidden hx:px-4" aria-label="table of contents">
     <div class="hextra-scrollbar hx:sticky hx:top-16 hx:overflow-y-auto hx:pr-4 hx:pt-6 hx:text-sm [hyphens:auto] hx:max-h-[calc(100vh-var(--navbar-height)-env(safe-area-inset-bottom))] hx:ltr:-mr-4 hx:rtl:-ml-4">
       {{- with .Fragments.Headings -}}
         <p class="hx:mb-4 hx:font-semibold hx:tracking-tight">{{ $onThisPage }}</p>
@@ -61,8 +61,8 @@
         </button>
       </div>
     </div>
-  {{ end -}}
-</nav>
+  </nav>
+{{ end -}}
 
 {{/* TOC subheadings component. This is a recursive component that renders a list of headings. */}}
 {{- define "toc-subheading" -}}


### PR DESCRIPTION
When a layout template is using `layouts/_partials/toc.html` disabling toc on a page doesn't fully disable the toc. The nav tag is left there and is empty, which restricts the width of the content on the page unnecessarily.

This change fixes that by removing the nav tag when the toc is disabled via frontmatter