### PR TITLE
fix(flexsearch): search colors

### DIFF
--- a/assets/js/flexsearch.js
+++ b/assets/js/flexsearch.js
@@ -405,11 +405,11 @@ document.addEventListener("DOMContentLoaded", function () {
     function handleMouseMove(e) {
       const target = e.target.closest('a');
       if (target) {
-        const active = resultsElement.querySelector('a.active');
+        const active = resultsElement.querySelector('a.hextra-search-active');
         if (active) {
-          active.classList.remove('active');
+          active.classList.remove('hextra-search-active');
         }
-        target.classList.add('active');
+        target.classList.add('hextra-search-active');
       }
     }
 


### PR DESCRIPTION
The search match color and the active item were not working.

To reproduce:
- https://imfing.github.io/hextra/
- search "logo" (no word highlight)
- and move the mouse cursor on the result items (no active item color changes)