### PR TITLE
feat(navbar): toggle theme inside navbar

### DIFF
--- a/exampleSite/content/docs/guide/configuration.fa.md
+++ b/exampleSite/content/docs/guide/configuration.fa.md
@@ -64,7 +64,7 @@ menu:
      params:
        icon: github
    ```
-5. Theme Toggle
+5. تبديل السمة
    ```yaml
     - name: Theme Toggle
       params:

--- a/exampleSite/content/docs/guide/configuration.fa.md
+++ b/exampleSite/content/docs/guide/configuration.fa.md
@@ -64,6 +64,12 @@ menu:
      params:
        icon: github
    ```
+5. Theme Toggle
+   ```yaml
+    - name: Theme Toggle
+      params:
+        type: theme-toggle
+   ```
 
 این آیتم‌های منو را می‌توان با تنظیم پارامتر `weight` مرتب کرد.
 

--- a/exampleSite/content/docs/guide/configuration.ja.md
+++ b/exampleSite/content/docs/guide/configuration.ja.md
@@ -64,7 +64,7 @@ menu:
      params:
        icon: github
    ```
-5. Theme Toggle
+5. テーマ切り替え
    ```yaml
     - name: Theme Toggle
       params:

--- a/exampleSite/content/docs/guide/configuration.ja.md
+++ b/exampleSite/content/docs/guide/configuration.ja.md
@@ -64,6 +64,12 @@ menu:
      params:
        icon: github
    ```
+5. Theme Toggle
+   ```yaml
+    - name: Theme Toggle
+      params:
+        type: theme-toggle
+   ```
 
 これらのメニュー項目は `weight` パラメータを設定することで並べ替えられます。
 

--- a/exampleSite/content/docs/guide/configuration.md
+++ b/exampleSite/content/docs/guide/configuration.md
@@ -64,6 +64,12 @@ There are different types of menu items:
      params:
        icon: github
    ```
+5. Theme Toggle
+   ```yaml
+    - name: Theme Toggle
+      params:
+        type: theme-toggle
+   ```
 
 These menu items can be sorted by setting the `weight` parameter.
 

--- a/exampleSite/content/docs/guide/configuration.zh-cn.md
+++ b/exampleSite/content/docs/guide/configuration.zh-cn.md
@@ -64,7 +64,7 @@ menu:
      params:
        icon: github
    ```
-5. Theme Toggle
+5. 主题切换
    ```yaml
     - name: Theme Toggle
       params:

--- a/exampleSite/content/docs/guide/configuration.zh-cn.md
+++ b/exampleSite/content/docs/guide/configuration.zh-cn.md
@@ -64,6 +64,12 @@ menu:
      params:
        icon: github
    ```
+5. Theme Toggle
+   ```yaml
+    - name: Theme Toggle
+      params:
+        type: theme-toggle
+   ```
 
 通过设置 `weight` 参数可以调整菜单项的排序。
 

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -94,6 +94,11 @@ menu:
       url: "https://github.com/imfing/hextra"
       params:
         icon: github
+    - name: Toggle Mode
+      weight: 8
+      params:
+        type: theme-toggle
+        hideLabel: true
     - identifier: development
       name: Development ↗
       url: https://imfing.github.io/hextra/versions/latest/

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -98,7 +98,6 @@ menu:
       weight: 8
       params:
         type: theme-toggle
-        hideLabel: true
     - identifier: development
       name: Development ↗
       url: https://imfing.github.io/hextra/versions/latest/

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -94,10 +94,6 @@ menu:
       url: "https://github.com/imfing/hextra"
       params:
         icon: github
-    - name: Toggle Mode
-      weight: 8
-      params:
-        type: theme-toggle
     - identifier: development
       name: Development ↗
       url: https://imfing.github.io/hextra/versions/latest/

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -38,7 +38,7 @@
             <span class="hx:sr-only">{{ or (T .Identifier) .Name | safeHTML }}</span>
           </a>
         {{- else if eq .Params.type "theme-toggle" -}}
-          {{- partial "theme-toggle.html" (dict "iconHeight" $iconHeight "textHeight" "hx:text-sm" "hideLabel" .Params.hideLabel) -}}
+          {{- partial "theme-toggle.html" (dict "iconHeight" $iconHeight "class" "hx:text-sm hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" "hideLabel" .Params.hideLabel) -}}
         {{- else -}}
           {{- $active := or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .) -}}
           {{- $activeClass := cond $active "hx:font-medium" "hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" -}}

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -37,7 +37,7 @@
             <span class="hx:sr-only">{{ or (T .Identifier) .Name | safeHTML }}</span>
           </a>
         {{- else if eq .Params.type "theme-toggle" -}}
-          {{- partial "theme-toggle.html" (dict "navbar" true "hideLabel" .Params.hideLabel) -}}
+          {{- partial "theme-toggle.html" (dict "iconHeight" 24 "textHeight" "hx:text-sm" "hideLabel" .Params.hideLabel) -}}
         {{- else -}}
           {{- $active := or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .) -}}
           {{- $activeClass := cond $active "hx:font-medium" "hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" -}}

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -38,7 +38,7 @@
             <span class="hx:sr-only">{{ or (T .Identifier) .Name | safeHTML }}</span>
           </a>
         {{- else if eq .Params.type "theme-toggle" -}}
-          {{- partial "theme-toggle.html" (dict "iconHeight" $iconHeight "class" "hx:text-sm hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" "hideLabel" (not .Params.label)) -}}
+          {{- partial "theme-toggle.html" (dict "iconHeight" $iconHeight "class" "hx:p-2" "hideLabel" (not .Params.label)) -}}
         {{- else -}}
           {{- $active := or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .) -}}
           {{- $activeClass := cond $active "hx:font-medium" "hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" -}}

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -36,6 +36,8 @@
             {{- partial "utils/icon.html" (dict "name" .Params.icon "attributes" "height=24") -}}
             <span class="hx:sr-only">{{ or (T .Identifier) .Name | safeHTML }}</span>
           </a>
+        {{- else if eq .Params.type "theme-toggle" -}}
+          {{- partial "theme-toggle.html" (dict "navbar" true "hideLabel" .Params.hideLabel) -}}
         {{- else -}}
           {{- $active := or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .) -}}
           {{- $activeClass := cond $active "hx:font-medium" "hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" -}}

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -7,6 +7,7 @@
   {{ end -}}
 {{- end -}}
 
+{{- $iconHeight := 24 -}}
 
 <div class="hextra-nav-container hx:sticky hx:top-0 hx:z-20 hx:w-full hx:bg-transparent hx:print:hidden">
   <div
@@ -33,11 +34,11 @@
         {{- if .Params.icon -}}
           {{- $rel := cond (eq .Params.icon "mastodon") "noreferrer me" "noreferrer" }}
           <a class="hx:p-2 hx:text-current" {{ if $external }}target="_blank" rel="{{ $rel }}"{{ end }} href="{{ $link }}" title="{{ or (T .Identifier) .Name | safeHTML }}">
-            {{- partial "utils/icon.html" (dict "name" .Params.icon "attributes" "height=24") -}}
+            {{- partial "utils/icon.html" (dict "name" .Params.icon "attributes" (printf "height=%d" $iconHeight)) -}}
             <span class="hx:sr-only">{{ or (T .Identifier) .Name | safeHTML }}</span>
           </a>
         {{- else if eq .Params.type "theme-toggle" -}}
-          {{- partial "theme-toggle.html" (dict "iconHeight" 24 "textHeight" "hx:text-sm" "hideLabel" .Params.hideLabel) -}}
+          {{- partial "theme-toggle.html" (dict "iconHeight" $iconHeight "textHeight" "hx:text-sm" "hideLabel" .Params.hideLabel) -}}
         {{- else -}}
           {{- $active := or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .) -}}
           {{- $activeClass := cond $active "hx:font-medium" "hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" -}}
@@ -96,7 +97,7 @@
 
 
     <button type="button" aria-label="Menu" class="hextra-hamburger-menu hx:cursor-pointer hx:-mr-2 hx:rounded-sm hx:p-2 hx:active:bg-gray-400/20 hx:md:hidden">
-      {{- partial "utils/icon.html" (dict "name" "hamburger-menu" "attributes" "height=24") -}}
+      {{- partial "utils/icon.html" (dict "name" "hamburger-menu" "attributes" (printf "height=%d" $iconHeight)) -}}
     </button>
   </nav>
 </div>

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -38,7 +38,7 @@
             <span class="hx:sr-only">{{ or (T .Identifier) .Name | safeHTML }}</span>
           </a>
         {{- else if eq .Params.type "theme-toggle" -}}
-          {{- partial "theme-toggle.html" (dict "iconHeight" $iconHeight "class" "hx:text-sm hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" "hideLabel" .Params.hideLabel) -}}
+          {{- partial "theme-toggle.html" (dict "iconHeight" $iconHeight "class" "hx:text-sm hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" "hideLabel" (not .Params.label)) -}}
         {{- else -}}
           {{- $active := or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .) -}}
           {{- $activeClass := cond $active "hx:font-medium" "hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" -}}

--- a/layouts/_partials/theme-toggle.html
+++ b/layouts/_partials/theme-toggle.html
@@ -4,18 +4,25 @@
 {{- $light := (T "light") | default "Light" -}}
 {{- $dark := (T "dark") | default "Dark" -}}
 
+{{- $navbar := .navbar | default false -}}
+{{- $iconHeight := 12 -}}
+{{- $textHeight := "hx:text-xs" -}}
+{{- if $navbar -}}
+  {{- $iconHeight = 24 -}}
+  {{- $textHeight = "hx:text-sm" -}}
+{{- end -}}
 
 <button
   title="{{ $changeTheme }}"
   data-theme="light"
-  class="hextra-theme-toggle hx:cursor-pointer hx:group hx:h-7 hx:rounded-md hx:px-2 hx:text-left hx:text-xs hx:font-medium hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400 hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50"
+  class="hextra-theme-toggle hx:cursor-pointer hx:group hx:h-7 hx:rounded-md hx:px-2 hx:text-left {{ $textHeight }} hx:font-medium hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400 hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50"
   type="button"
   aria-label="{{ $changeTheme }}"
 >
   <div class="hx:flex hx:items-center hx:gap-2 hx:capitalize">
-    {{- partial "utils/icon.html" (dict "name" "sun" "attributes" "height=12 class=\"hx:group-data-[theme=light]:hidden\"") -}}
+    {{- partial "utils/icon.html" (dict "name" "sun" "attributes" (printf "height=%d class=\"hx:group-data-[theme=light]:hidden\"" $iconHeight)) -}}
     {{- if not $hideLabel }}<span class="hx:group-data-[theme=light]:hidden">{{ $light }}</span>{{ end -}}
-    {{- partial "utils/icon.html" (dict "name" "moon" "attributes" "height=12 class=\"hx:group-data-[theme=dark]:hidden\"") -}}
+    {{- partial "utils/icon.html" (dict "name" "moon" "attributes" (printf "height=%d class=\"hx:group-data-[theme=dark]:hidden\"" $iconHeight)) -}}
     {{- if not $hideLabel }}<span class="hx:group-data-[theme=dark]:hidden">{{ $dark }}</span>{{ end -}}
   </div>
 </button>

--- a/layouts/_partials/theme-toggle.html
+++ b/layouts/_partials/theme-toggle.html
@@ -1,6 +1,6 @@
 {{- $hideLabel := .hideLabel | default false -}}
 {{- $iconHeight := .iconHeight | default 12 -}}
-{{- $textHeight := .textHeight | default "hx:text-xs" -}}
+{{- $class := .class | default "hx:px-2 hx:text-xs hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50" -}}
 
 {{- $changeTheme := (T "changeTheme") | default "Change theme" -}}
 {{- $light := (T "light") | default "Light" -}}
@@ -9,7 +9,7 @@
 <button
   title="{{ $changeTheme }}"
   data-theme="light"
-  class="hextra-theme-toggle hx:cursor-pointer hx:group hx:h-7 hx:rounded-md hx:px-2 hx:text-left {{ $textHeight }} hx:font-medium hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400 hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50"
+  class="hextra-theme-toggle hx:cursor-pointer hx:group hx:h-7 hx:rounded-md hx:text-left {{ $class }} hx:font-medium hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400"
   type="button"
   aria-label="{{ $changeTheme }}"
 >

--- a/layouts/_partials/theme-toggle.html
+++ b/layouts/_partials/theme-toggle.html
@@ -9,7 +9,7 @@
 <button
   title="{{ $changeTheme }}"
   data-theme="light"
-  class="hextra-theme-toggle hx:cursor-pointer hx:group hx:h-7 hx:rounded-md hx:text-left {{ $class }}"
+  class="hextra-theme-toggle hx:cursor-pointer hx:group hx:rounded-md hx:text-left {{ $class }}"
   type="button"
   aria-label="{{ $changeTheme }}"
 >

--- a/layouts/_partials/theme-toggle.html
+++ b/layouts/_partials/theme-toggle.html
@@ -1,6 +1,6 @@
 {{- $hideLabel := .hideLabel -}}
 {{- $iconHeight := .iconHeight | default 12 -}}
-{{- $class := .class | default "hx:px-2 hx:text-xs hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50" -}}
+{{- $class := .class | default "hx:px-2 hx:text-xs hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50 hx:font-medium hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400" -}}
 
 {{- $changeTheme := (T "changeTheme") | default "Change theme" -}}
 {{- $light := (T "light") | default "Light" -}}
@@ -9,7 +9,7 @@
 <button
   title="{{ $changeTheme }}"
   data-theme="light"
-  class="hextra-theme-toggle hx:cursor-pointer hx:group hx:h-7 hx:rounded-md hx:text-left {{ $class }} hx:font-medium hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400"
+  class="hextra-theme-toggle hx:cursor-pointer hx:group hx:h-7 hx:rounded-md hx:text-left {{ $class }}"
   type="button"
   aria-label="{{ $changeTheme }}"
 >

--- a/layouts/_partials/theme-toggle.html
+++ b/layouts/_partials/theme-toggle.html
@@ -1,16 +1,10 @@
 {{- $hideLabel := .hideLabel | default false -}}
+{{- $iconHeight := .iconHeight | default 12 -}}
+{{- $textHeight := .textHeight | default "hx:text-xs" -}}
 
 {{- $changeTheme := (T "changeTheme") | default "Change theme" -}}
 {{- $light := (T "light") | default "Light" -}}
 {{- $dark := (T "dark") | default "Dark" -}}
-
-{{- $navbar := .navbar | default false -}}
-{{- $iconHeight := 12 -}}
-{{- $textHeight := "hx:text-xs" -}}
-{{- if $navbar -}}
-  {{- $iconHeight = 24 -}}
-  {{- $textHeight = "hx:text-sm" -}}
-{{- end -}}
 
 <button
   title="{{ $changeTheme }}"

--- a/layouts/_partials/theme-toggle.html
+++ b/layouts/_partials/theme-toggle.html
@@ -1,4 +1,4 @@
-{{- $hideLabel := .hideLabel | default false -}}
+{{- $hideLabel := .hideLabel -}}
 {{- $iconHeight := .iconHeight | default 12 -}}
 {{- $class := .class | default "hx:px-2 hx:text-xs hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50" -}}
 


### PR DESCRIPTION
The PR is the same as #499 but updated to Tailwind 4 and with some minor changes.

To answer the question about `12`/`24`. (https://github.com/imfing/hextra/pull/499/files#r1874791928)

`12` is the height of the icons/svg inside the theme toggle:
- https://github.com/imfing/hextra/blob/f79bd1a8cf8d5a5df2d3988f2cbbb91a4af072e5/layouts/_partials/theme-toggle.html#L16
- https://github.com/imfing/hextra/blob/f79bd1a8cf8d5a5df2d3988f2cbbb91a4af072e5/layouts/_partials/theme-toggle.html#L18

`24` is the height of the icons/svg inside the navbar:
- https://github.com/imfing/hextra/blob/f79bd1a8cf8d5a5df2d3988f2cbbb91a4af072e5/layouts/_partials/navbar.html#L36
- https://github.com/imfing/hextra/blob/f79bd1a8cf8d5a5df2d3988f2cbbb91a4af072e5/layouts/_partials/navbar.html#L97

Closes #499
Fixes #343