### PR TITLE
feat(navbar): language switcher

### DIFF
--- a/assets/js/lang.js
+++ b/assets/js/lang.js
@@ -7,25 +7,26 @@
       const optionsElement = switcher.nextElementSibling;
       optionsElement.classList.toggle('hx:hidden');
 
-      // Calculate position of language options element
+      // Calculate the position of a language options element.
       const switcherRect = switcher.getBoundingClientRect();
+
+      const isOnTop = switcher.dataset.location === 'top';
+      const isRTL = document.body.dir === 'rtl'
 
       // Stuck on the left side of the switcher.
       let translateX = switcherRect.left;
+
+      if (isOnTop && !isRTL || !isOnTop && isRTL) {
+        // Stuck on the right side of the switcher.
+        translateX = switcherRect.right - optionsElement.clientWidth;
+      }
+
       // Stuck on the top of the switcher.
       let translateY = switcherRect.top - window.innerHeight - 15;
 
-      if (switcher.dataset.location === 'top') {
-        if (document.body.dir !== 'rtl') {
-          // Stuck on the right side of the switcher.
-          translateX = switcherRect.right - optionsElement.clientWidth;
-        }
-
+      if (isOnTop) {
         // Stuck on the bottom of the switcher.
         translateY = switcherRect.top - window.innerHeight + 180;
-      } else if (document.body.dir === 'rtl') {
-        // Stuck on the right side of the switcher.
-        translateX = switcherRect.right - optionsElement.clientWidth;
       }
 
       optionsElement.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;

--- a/assets/js/lang.js
+++ b/assets/js/lang.js
@@ -10,16 +10,21 @@
       // Calculate position of language options element
       const switcherRect = switcher.getBoundingClientRect();
 
+      // Stuck on the left side of the switcher.
       let translateX = switcherRect.left;
+      // Stuck on the top of the switcher.
       let translateY = switcherRect.top - window.innerHeight - 15;
 
       if (switcher.dataset.location === 'top') {
         if (document.body.dir !== 'rtl') {
+          // Stuck on the right side of the switcher.
           translateX = switcherRect.right - optionsElement.clientWidth;
         }
 
+        // Stuck on the bottom of the switcher.
         translateY = switcherRect.top - window.innerHeight + 180;
       } else if (document.body.dir === 'rtl') {
+        // Stuck on the right side of the switcher.
         translateX = switcherRect.right - optionsElement.clientWidth;
       }
 

--- a/assets/js/lang.js
+++ b/assets/js/lang.js
@@ -19,6 +19,8 @@
         }
 
         translateY = switcherRect.top - window.innerHeight + 180;
+      } else if (document.body.dir === 'rtl') {
+        translateX = switcherRect.right - optionsElement.clientWidth;
       }
 
       optionsElement.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;

--- a/assets/js/lang.js
+++ b/assets/js/lang.js
@@ -10,6 +10,9 @@
       // Calculate the position of a language options element.
       const switcherRect = switcher.getBoundingClientRect();
 
+      // Must be called before optionsElement.clientWidth.
+      optionsElement.style.minWidth = `${Math.max(switcherRect.width, 50)}px`;
+
       const isOnTop = switcher.dataset.location === 'top';
       const isRTL = document.body.dir === 'rtl'
 
@@ -30,7 +33,6 @@
       }
 
       optionsElement.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
-      optionsElement.style.minWidth = `${Math.max(switcherRect.width, 50)}px`;
     });
   });
 

--- a/assets/js/lang.js
+++ b/assets/js/lang.js
@@ -13,7 +13,7 @@
       let translateX = switcherRect.left;
       let translateY = switcherRect.top - window.innerHeight - 15;
 
-      if (switcher.dataset.location === 'navbar') {
+      if (switcher.dataset.location === 'top') {
         if (document.body.dir !== 'rtl') {
           translateX = switcherRect.right - optionsElement.clientWidth;
         }

--- a/assets/js/lang.js
+++ b/assets/js/lang.js
@@ -9,8 +9,19 @@
 
       // Calculate position of language options element
       const switcherRect = switcher.getBoundingClientRect();
-      const translateY = switcherRect.top - window.innerHeight - 15;
-      optionsElement.style.transform = `translate3d(${switcherRect.left}px, ${translateY}px, 0)`;
+
+      let translateX = switcherRect.left;
+      let translateY = switcherRect.top - window.innerHeight - 15;
+
+      if (switcher.dataset.location === 'navbar') {
+        if (document.body.dir !== 'rtl') {
+          translateX = switcherRect.right - optionsElement.clientWidth;
+        }
+
+        translateY = switcherRect.top - window.innerHeight + 180;
+      }
+
+      optionsElement.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
       optionsElement.style.minWidth = `${Math.max(switcherRect.width, 50)}px`;
     });
   });

--- a/exampleSite/content/docs/guide/configuration.fa.md
+++ b/exampleSite/content/docs/guide/configuration.fa.md
@@ -70,6 +70,12 @@ menu:
       params:
         type: theme-toggle
    ```
+6. مُبدِّل اللغة
+   ```yaml
+    - name: مُبدِّل اللغة
+      params:
+        type: language-switch
+   ```
 
 این آیتم‌های منو را می‌توان با تنظیم پارامتر `weight` مرتب کرد.
 

--- a/exampleSite/content/docs/guide/configuration.fa.md
+++ b/exampleSite/content/docs/guide/configuration.fa.md
@@ -69,12 +69,15 @@ menu:
     - name: Theme Toggle
       params:
         type: theme-toggle
+        label: true # optional, default is false
    ```
 6. مُبدِّل اللغة
    ```yaml
     - name: مُبدِّل اللغة
       params:
         type: language-switch
+        label: true # optional, default is false
+        icon: "globe-alt" # optional, default is "translate"
    ```
 
 این آیتم‌های منو را می‌توان با تنظیم پارامتر `weight` مرتب کرد.

--- a/exampleSite/content/docs/guide/configuration.ja.md
+++ b/exampleSite/content/docs/guide/configuration.ja.md
@@ -69,12 +69,15 @@ menu:
     - name: Theme Toggle
       params:
         type: theme-toggle
+        label: true # optional, default is false
    ```
 6. 言語スイッチャー
    ```yaml
     - name: 言語スイッチャー
       params:
         type: language-switch
+        label: true # optional, default is false
+        icon: "globe-alt" # optional, default is "translate"
    ```
 
 これらのメニュー項目は `weight` パラメータを設定することで並べ替えられます。

--- a/exampleSite/content/docs/guide/configuration.ja.md
+++ b/exampleSite/content/docs/guide/configuration.ja.md
@@ -70,6 +70,12 @@ menu:
       params:
         type: theme-toggle
    ```
+6. 言語スイッチャー
+   ```yaml
+    - name: 言語スイッチャー
+      params:
+        type: language-switch
+   ```
 
 これらのメニュー項目は `weight` パラメータを設定することで並べ替えられます。
 

--- a/exampleSite/content/docs/guide/configuration.md
+++ b/exampleSite/content/docs/guide/configuration.md
@@ -69,12 +69,15 @@ There are different types of menu items:
     - name: Theme Toggle
       params:
         type: theme-toggle
+        label: true # optional, default is false
    ```
 6. Language Switcher
    ```yaml
     - name: Language Switcher
       params:
         type: language-switch
+        label: true # optional, default is false
+        icon: "globe-alt" # optional, default is "translate"
    ```
 
 These menu items can be sorted by setting the `weight` parameter.

--- a/exampleSite/content/docs/guide/configuration.md
+++ b/exampleSite/content/docs/guide/configuration.md
@@ -70,6 +70,12 @@ There are different types of menu items:
       params:
         type: theme-toggle
    ```
+6. Language Switcher
+   ```yaml
+    - name: Language Switcher
+      params:
+        type: language-switch
+   ```
 
 These menu items can be sorted by setting the `weight` parameter.
 

--- a/exampleSite/content/docs/guide/configuration.zh-cn.md
+++ b/exampleSite/content/docs/guide/configuration.zh-cn.md
@@ -69,12 +69,15 @@ menu:
     - name: Theme Toggle
       params:
         type: theme-toggle
+        label: true # optional, default is false
    ```
 6. 语言切换器
    ```yaml
     - name: 语言切换器
       params:
         type: language-switch
+        label: true # optional, default is false
+        icon: "globe-alt" # optional, default is "translate"
    ```
 
 通过设置 `weight` 参数可以调整菜单项的排序。

--- a/exampleSite/content/docs/guide/configuration.zh-cn.md
+++ b/exampleSite/content/docs/guide/configuration.zh-cn.md
@@ -70,6 +70,12 @@ menu:
       params:
         type: theme-toggle
    ```
+6. 语言切换器
+   ```yaml
+    - name: 语言切换器
+      params:
+        type: language-switch
+   ```
 
 通过设置 `weight` 参数可以调整菜单项的排序。
 

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -94,6 +94,10 @@ menu:
       url: "https://github.com/imfing/hextra"
       params:
         icon: github
+    - name: Language switch
+      weight: 9
+      params:
+        type: language-switch
     - identifier: development
       name: Development ↗
       url: https://imfing.github.io/hextra/versions/latest/

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -94,10 +94,6 @@ menu:
       url: "https://github.com/imfing/hextra"
       params:
         icon: github
-    - name: Language switch
-      weight: 9
-      params:
-        type: language-switch
     - identifier: development
       name: Development ↗
       url: https://imfing.github.io/hextra/versions/latest/

--- a/layouts/_partials/language-switch.html
+++ b/layouts/_partials/language-switch.html
@@ -1,4 +1,5 @@
 {{- $page := .context -}}
+{{- $iconName := .iconName | default "globe-alt" -}}
 {{- $iconHeight := .iconHeight | default 12 -}}
 {{- $location := .location -}}
 
@@ -20,7 +21,7 @@
       aria-label="{{ $changeLanguage }}"
     >
       <div class="hx:flex hx:items-center hx:gap-2 hx:capitalize">
-        {{- partial "utils/icon" (dict "name" "translate" "attributes" (printf "height=%d" $iconHeight)) -}}
+        {{- partial "utils/icon" (dict "name" $iconName "attributes" (printf "height=%d" $iconHeight)) -}}
         {{- if not $hideLabel }}<span>{{ site.Language.LanguageName }}</span>{{ end -}}
       </div>
     </button>

--- a/layouts/_partials/language-switch.html
+++ b/layouts/_partials/language-switch.html
@@ -2,6 +2,8 @@
 {{- $iconHeight := .iconHeight | default 12 -}}
 {{- $location := .location -}}
 
+{{- $class := .class | default "hx:px-2 hx:text-xs hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400 hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50" -}}
+
 {{- $grow := .grow -}}
 {{- $hideLabel := .hideLabel | default false -}}
 
@@ -13,7 +15,7 @@
       title="{{ $changeLanguage }}"
       data-state="closed"
       data-location="{{ $location }}"
-      class="hextra-language-switcher hx:cursor-pointer hx:h-7 hx:rounded-md hx:px-2 hx:text-left hx:text-xs hx:font-medium hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400 hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50 hx:grow"
+      class="hextra-language-switcher hx:cursor-pointer hx:h-7 hx:rounded-md hx:text-left hx:font-medium {{ $class }} hx:grow"
       type="button"
       aria-label="{{ $changeLanguage }}"
     >

--- a/layouts/_partials/language-switch.html
+++ b/layouts/_partials/language-switch.html
@@ -3,7 +3,7 @@
 {{- $iconHeight := .iconHeight | default 12 -}}
 {{- $location := .location -}}
 
-{{- $class := .class | default "hx:px-2 hx:text-xs hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400 hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50" -}}
+{{- $class := .class | default "hx:h-7 hx:px-2 hx:text-xs hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400 hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50" -}}
 
 {{- $grow := .grow -}}
 {{- $hideLabel := .hideLabel | default false -}}

--- a/layouts/_partials/language-switch.html
+++ b/layouts/_partials/language-switch.html
@@ -15,12 +15,12 @@
       title="{{ $changeLanguage }}"
       data-state="closed"
       data-location="{{ $location }}"
-      class="hextra-language-switcher hx:cursor-pointer hx:h-7 hx:rounded-md hx:text-left hx:font-medium {{ $class }} hx:grow"
+      class="hextra-language-switcher hx:cursor-pointer hx:rounded-md hx:text-left hx:font-medium {{ $class }} hx:grow"
       type="button"
       aria-label="{{ $changeLanguage }}"
     >
       <div class="hx:flex hx:items-center hx:gap-2 hx:capitalize">
-        {{- partial "utils/icon" (dict "name" "globe-alt" "attributes" (printf "height=%d" $iconHeight)) -}}
+        {{- partial "utils/icon" (dict "name" "translate" "attributes" (printf "height=%d" $iconHeight)) -}}
         {{- if not $hideLabel }}<span>{{ site.Language.LanguageName }}</span>{{ end -}}
       </div>
     </button>

--- a/layouts/_partials/language-switch.html
+++ b/layouts/_partials/language-switch.html
@@ -1,4 +1,6 @@
 {{- $page := .context -}}
+{{- $iconHeight := .iconHeight | default 12 -}}
+{{- $location := .location -}}
 
 {{- $grow := .grow -}}
 {{- $hideLabel := .hideLabel | default false -}}
@@ -10,12 +12,13 @@
     <button
       title="{{ $changeLanguage }}"
       data-state="closed"
+      data-location="{{ $location }}"
       class="hextra-language-switcher hx:cursor-pointer hx:h-7 hx:rounded-md hx:px-2 hx:text-left hx:text-xs hx:font-medium hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400 hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50 hx:grow"
       type="button"
       aria-label="{{ $changeLanguage }}"
     >
       <div class="hx:flex hx:items-center hx:gap-2 hx:capitalize">
-        {{- partial "utils/icon" (dict "name" "globe-alt" "attributes" "height=12") -}}
+        {{- partial "utils/icon" (dict "name" "globe-alt" "attributes" (printf "height=%d" $iconHeight)) -}}
         {{- if not $hideLabel }}<span>{{ site.Language.LanguageName }}</span>{{ end -}}
       </div>
     </button>

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -7,6 +7,7 @@
   {{ end -}}
 {{- end -}}
 
+{{- $page := . -}}
 {{- $iconHeight := 24 -}}
 
 <div class="hextra-nav-container hx:sticky hx:top-0 hx:z-20 hx:w-full hx:bg-transparent hx:print:hidden">
@@ -39,6 +40,8 @@
           </a>
         {{- else if eq .Params.type "theme-toggle" -}}
           {{- partial "theme-toggle.html" (dict "iconHeight" $iconHeight "class" "hx:p-2" "hideLabel" (not .Params.label)) -}}
+        {{- else if eq .Params.type "language-switch" -}}
+          {{- partial "language-switch" (dict "context" $page "grow" false "hideLabel" (not .Params.label) "iconHeight" 24 "location" "navbar") -}}
         {{- else -}}
           {{- $active := or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .) -}}
           {{- $activeClass := cond $active "hx:font-medium" "hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" -}}

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -41,7 +41,7 @@
         {{- else if eq .Params.type "theme-toggle" -}}
           {{- partial "theme-toggle.html" (dict "iconHeight" $iconHeight "class" "hx:p-2" "hideLabel" (not .Params.label)) -}}
         {{- else if eq .Params.type "language-switch" -}}
-          {{- partial "language-switch" (dict "context" $page "grow" false "hideLabel" (not .Params.label) "iconHeight" 24 "location" "navbar") -}}
+          {{- partial "language-switch" (dict "context" $page "grow" false "hideLabel" (not .Params.label) "iconHeight" 24 "location" "top" "class" "hx:px-2") -}}
         {{- else -}}
           {{- $active := or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .) -}}
           {{- $activeClass := cond $active "hx:font-medium" "hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" -}}

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -41,7 +41,7 @@
         {{- else if eq .Params.type "theme-toggle" -}}
           {{- partial "theme-toggle.html" (dict "iconHeight" $iconHeight "class" "hx:p-2" "hideLabel" (not .Params.label)) -}}
         {{- else if eq .Params.type "language-switch" -}}
-          {{- partial "language-switch" (dict "context" $page "grow" false "hideLabel" (not .Params.label) "iconHeight" $iconHeight "location" "top" "class" "hx:px-2") -}}
+          {{- partial "language-switch" (dict "context" $page "grow" false "hideLabel" (not .Params.label) "iconHeight" $iconHeight "location" "top" "class" "hx:p-2") -}}
         {{- else -}}
           {{- $active := or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .) -}}
           {{- $activeClass := cond $active "hx:font-medium" "hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" -}}

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -41,7 +41,7 @@
         {{- else if eq .Params.type "theme-toggle" -}}
           {{- partial "theme-toggle.html" (dict "iconHeight" $iconHeight "class" "hx:p-2" "hideLabel" (not .Params.label)) -}}
         {{- else if eq .Params.type "language-switch" -}}
-          {{- partial "language-switch" (dict "context" $page "grow" false "hideLabel" (not .Params.label) "iconName" "translate" "iconHeight" $iconHeight "location" "top" "class" "hx:p-2") -}}
+          {{- partial "language-switch" (dict "context" $page "grow" false "hideLabel" (not .Params.label) "iconName" (.Params.icon | default "translate") "iconHeight" $iconHeight "location" "top" "class" "hx:p-2") -}}
         {{- else -}}
           {{- $active := or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .) -}}
           {{- $activeClass := cond $active "hx:font-medium" "hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" -}}

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -41,7 +41,7 @@
         {{- else if eq .Params.type "theme-toggle" -}}
           {{- partial "theme-toggle.html" (dict "iconHeight" $iconHeight "class" "hx:p-2" "hideLabel" (not .Params.label)) -}}
         {{- else if eq .Params.type "language-switch" -}}
-          {{- partial "language-switch" (dict "context" $page "grow" false "hideLabel" (not .Params.label) "iconHeight" $iconHeight "location" "top" "class" "hx:p-2") -}}
+          {{- partial "language-switch" (dict "context" $page "grow" false "hideLabel" (not .Params.label) "iconName" "translate" "iconHeight" $iconHeight "location" "top" "class" "hx:p-2") -}}
         {{- else -}}
           {{- $active := or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .) -}}
           {{- $activeClass := cond $active "hx:font-medium" "hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" -}}

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -41,7 +41,7 @@
         {{- else if eq .Params.type "theme-toggle" -}}
           {{- partial "theme-toggle.html" (dict "iconHeight" $iconHeight "class" "hx:p-2" "hideLabel" (not .Params.label)) -}}
         {{- else if eq .Params.type "language-switch" -}}
-          {{- partial "language-switch" (dict "context" $page "grow" false "hideLabel" (not .Params.label) "iconHeight" 24 "location" "top" "class" "hx:px-2") -}}
+          {{- partial "language-switch" (dict "context" $page "grow" false "hideLabel" (not .Params.label) "iconHeight" $iconHeight "location" "top" "class" "hx:px-2") -}}
         {{- else -}}
           {{- $active := or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .) -}}
           {{- $activeClass := cond $active "hx:font-medium" "hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" -}}

--- a/layouts/_partials/theme-toggle.html
+++ b/layouts/_partials/theme-toggle.html
@@ -1,6 +1,6 @@
 {{- $hideLabel := .hideLabel -}}
 {{- $iconHeight := .iconHeight | default 12 -}}
-{{- $class := .class | default "hx:px-2 hx:text-xs hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50 hx:font-medium hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400" -}}
+{{- $class := .class | default "hx:h-7 hx:px-2 hx:text-xs hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50 hx:font-medium hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400" -}}
 
 {{- $changeTheme := (T "changeTheme") | default "Change theme" -}}
 {{- $light := (T "light") | default "Light" -}}


### PR DESCRIPTION
Same approach as https://github.com/imfing/hextra/pull/759, but for the language switcher.

This is more complex than the theme toggle because of the transformation computation.

Tested with `rtl` (Farsi) and `ltr` (English), and on desktop and mobile.

I added an item to the example site's navbar to ease the review, as the site is previewed by Netlify.

I also fixed a pre-existing bug with `rtl` on mobile or small screens.

Closes #662
Fixes #654
