### PR TITLE
fix(giscus): theme and language

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -31,7 +31,7 @@ languages:
     title: هگزترا
   ja:
     languageName: 日本語
-    languageCode: ja
+    languageCode: ja-JP
     weight: 3
     title: Hextra
   zh-cn:

--- a/layouts/_partials/components/giscus.html
+++ b/layouts/_partials/components/giscus.html
@@ -64,7 +64,7 @@
     // Dynamically create script tag
     const giscusScript = document.createElement("script");
     Object.entries(giscusAttributes).forEach(([key, value]) => giscusScript.setAttribute(key, value));
-    document.getElementById('giscus').appendChild(giscusScript);
+    document.getElementById('giscus-hextra-bb112b9f807c37c1752e5da6a1652a29').appendChild(giscusScript);
 
     // Listen for system theme changes
     window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", setGiscusTheme);
@@ -77,7 +77,7 @@
   });
 </script>
 
-<div id="giscus"></div>
+<div id="giscus-hextra-bb112b9f807c37c1752e5da6a1652a29"></div>
 {{- else -}}
   {{ warnf "giscus is not configured" }}
 {{- end -}}

--- a/layouts/_partials/components/giscus.html
+++ b/layouts/_partials/components/giscus.html
@@ -6,7 +6,7 @@
 
 {{- with site.Params.comments.giscus -}}
 <script>
-   function getGiscusTheme() {
+  function getGiscusTheme() {
     const giscussTheme = '{{ .theme }}';
     if (giscussTheme === 'light' || giscussTheme === 'dark') {
       return giscussTheme;
@@ -30,17 +30,18 @@
   }
 
   function setGiscusTheme() {
-    function sendMessage(message) {
-      const iframe = document.querySelector('iframe.giscus-frame');
-      if (!iframe) return;
-      iframe.contentWindow.postMessage({ giscus: message }, 'https://giscus.app');
+    const iframe = document.querySelector('iframe.giscus-frame');
+    if (!iframe) return;
+
+    const msg = {
+      giscus: {
+        setConfig: {
+          theme: getGiscusTheme(),
+        },
+      },
     }
 
-    sendMessage({
-      setConfig: {
-        theme: getGiscusTheme(),
-      },
-    });
+    iframe.contentWindow.postMessage(msg, 'https://giscus.app');
   }
 
   document.addEventListener('DOMContentLoaded', function () {

--- a/layouts/_partials/components/giscus.html
+++ b/layouts/_partials/components/giscus.html
@@ -1,4 +1,8 @@
-{{- $lang := site.Language.LanguageCode | default `en` -}}
+{{- $lang := site.Language.Lang | default `en` -}}
+{{- if hasPrefix $lang "zh" -}}
+  {{- /* See: https://github.com/giscus/giscus/tree/main/locales */}}
+  {{- $lang = site.Language.LanguageCode | default `zh-CN` -}}
+{{- end -}}
 
 {{- with site.Params.comments.giscus -}}
 <script>

--- a/layouts/_partials/components/giscus.html
+++ b/layouts/_partials/components/giscus.html
@@ -13,15 +13,26 @@
   }
   
   function getGiscusTheme() {
-    let giscusTheme = "{{ (string .theme) | default `light` }}";
-    let hugoTheme = getHugoTheme();
-    if(hugoTheme == 'light') {
-      return giscusTheme.replace('dark', 'light');
+    const giscussTheme = '{{ .theme }}';
+    if (giscussTheme === 'light' || giscussTheme === 'dark') {
+      return giscussTheme;
     }
-    if(hugoTheme == 'dark') {
-      return giscusTheme.replace('light', 'dark');
+
+    const hugoTheme = getHugoTheme();
+    if (hugoTheme === 'light' || hugoTheme === 'dark') {
+      return hugoTheme;
     }
-    return giscusTheme;
+
+    if (hugoTheme === 'system') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    const defaultTheme = '{{ site.Params.theme.default }}';
+    if (defaultTheme === 'light' || defaultTheme === 'dark') {
+      return defaultTheme;
+    }
+
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 
   function setGiscusTheme() {

--- a/layouts/_partials/components/giscus.html
+++ b/layouts/_partials/components/giscus.html
@@ -6,23 +6,13 @@
 
 {{- with site.Params.comments.giscus -}}
 <script>
-  /*
-   * "preferred color scheme" theme in giscus works using "prefers-color-scheme" in media query.
-   * but, hugo's theme switch function works by using "color-theme" in local storage.
-   * This solution was created with reference to:
-   * https://github.com/giscus/giscus/issues/336#issuecomment-1214366281
-  */
-  function getHugoTheme() {
-    return localStorage.getItem("color-theme");
-  }
-  
-  function getGiscusTheme() {
+   function getGiscusTheme() {
     const giscussTheme = '{{ .theme }}';
     if (giscussTheme === 'light' || giscussTheme === 'dark') {
       return giscussTheme;
     }
 
-    const hugoTheme = getHugoTheme();
+    const hugoTheme = localStorage.getItem("color-theme");
     if (hugoTheme === 'light' || hugoTheme === 'dark') {
       return hugoTheme;
     }

--- a/layouts/_partials/components/giscus.html
+++ b/layouts/_partials/components/giscus.html
@@ -65,6 +65,7 @@
     // Dynamically create script tag
     const giscusScript = document.createElement("script");
     Object.entries(giscusAttributes).forEach(([key, value]) => giscusScript.setAttribute(key, value));
+    // Random hash id to avoid conflicts with titles inside pages.
     document.getElementById('giscus-hextra-bb112b9f807c37c1752e5da6a1652a29').appendChild(giscusScript);
 
     // Listen for system theme changes

--- a/layouts/_partials/components/giscus.html
+++ b/layouts/_partials/components/giscus.html
@@ -7,9 +7,9 @@
 {{- with site.Params.comments.giscus -}}
 <script>
   function getGiscusTheme() {
-    const giscussTheme = '{{ .theme }}';
-    if (giscussTheme === 'light' || giscussTheme === 'dark') {
-      return giscussTheme;
+    const giscusTheme = '{{ .theme }}';
+    if (giscusTheme === 'light' || giscusTheme === 'dark') {
+      return giscusTheme;
     }
 
     const hugoTheme = localStorage.getItem("color-theme");

--- a/layouts/_partials/components/giscus.html
+++ b/layouts/_partials/components/giscus.html
@@ -45,6 +45,7 @@
       if (!iframe) return;
       iframe.contentWindow.postMessage({ giscus: message }, 'https://giscus.app');
     }
+
     sendMessage({
       setConfig: {
         theme: getGiscusTheme(),
@@ -75,10 +76,13 @@
     Object.entries(giscusAttributes).forEach(([key, value]) => giscusScript.setAttribute(key, value));
     document.getElementById('giscus').appendChild(giscusScript);
 
+    // Listen for system theme changes
+    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", setGiscusTheme);
+
     // Update giscus theme when theme switcher is clicked
-    const toggles = document.querySelectorAll(".hextra-theme-toggle");
-    if (toggles) {
-      toggles.forEach(toggle => toggle.addEventListener('click', setGiscusTheme));
+    const themeToggleOptions = document.querySelectorAll(".hextra-theme-toggle-options p");
+    if (themeToggleOptions) {
+      themeToggleOptions.forEach(toggle => toggle.addEventListener('click', setGiscusTheme));
     }
   });
 </script>


### PR DESCRIPTION
- Fixes the support of the `system` theme
- Fixes theme switching
- Fixes language
- Fixes Giscuss inside the example page `docs/advanced/comments/`

Closes #358