### PR TITLE
fix(navbar): menu positions

### DIFF
--- a/assets/js/lang.js
+++ b/assets/js/lang.js
@@ -32,7 +32,7 @@
 
       if (isOnTop) {
         // Stuck on the bottom of the switcher.
-        translateY = switcherRect.top - window.innerHeight + 180;
+        translateY = switcherRect.top - window.innerHeight + optionsElement.clientHeight + switcher.clientHeight + 10;
       }
 
       optionsElement.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;

--- a/assets/js/lang.js
+++ b/assets/js/lang.js
@@ -1,43 +1,17 @@
 (function () {
   const languageSwitchers = document.querySelectorAll('.hextra-language-switcher');
+
   languageSwitchers.forEach((switcher) => {
     switcher.addEventListener('click', (e) => {
       e.preventDefault();
 
       switcher.dataset.state = switcher.dataset.state === 'open' ? 'closed' : 'open';
 
-      const optionsElement = switcher.nextElementSibling;
-
-      optionsElement.classList.toggle('hx:hidden');
-
-      // Calculate the position of a language options element.
-      const switcherRect = switcher.getBoundingClientRect();
-
-      // Must be called before optionsElement.clientWidth.
-      optionsElement.style.minWidth = `${Math.max(switcherRect.width, 50)}px`;
-
-      const isOnTop = switcher.dataset.location === 'top';
-      const isRTL = document.body.dir === 'rtl'
-
-      // Stuck on the left side of the switcher.
-      let translateX = switcherRect.left;
-
-      if (isOnTop && !isRTL || !isOnTop && isRTL) {
-        // Stuck on the right side of the switcher.
-        translateX = switcherRect.right - optionsElement.clientWidth;
-      }
-
-      // Stuck on the top of the switcher.
-      let translateY = switcherRect.top - window.innerHeight - 15;
-
-      if (isOnTop) {
-        // Stuck on the bottom of the switcher.
-        translateY = switcherRect.top - window.innerHeight + optionsElement.clientHeight + switcher.clientHeight + 10;
-      }
-
-      optionsElement.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
+      toggleMenu(switcher);
     });
   });
+
+  window.addEventListener("resize", () => languageSwitchers.forEach(resizeMenu))
 
   // Dismiss language switcher when clicking outside
   document.addEventListener('click', (e) => {

--- a/assets/js/switcher-menu.js
+++ b/assets/js/switcher-menu.js
@@ -23,7 +23,7 @@ function computeMenuTranslation(switcher, optionsElement) {
 
   if (isOnTop) {
     // Stuck on the bottom of the switcher.
-    y = switcherRect.top - window.innerHeight + optionsElement.clientHeight + switcher.clientHeight + 10;
+    y = switcherRect.top - window.innerHeight + optionsElement.clientHeight + switcher.clientHeight + 4;
   }
 
   return { x: x, y: y };

--- a/assets/js/switcher-menu.js
+++ b/assets/js/switcher-menu.js
@@ -1,0 +1,52 @@
+function computeMenuTranslation(switcher, optionsElement) {
+  // Calculate the position of a language options element.
+  const switcherRect = switcher.getBoundingClientRect();
+
+  // Must be called before optionsElement.clientWidth.
+  optionsElement.style.minWidth = `${Math.max(switcherRect.width, 50)}px`;
+
+  const isOnTop = switcher.dataset.location === 'top';
+  const isOnBottom = switcher.dataset.location === 'bottom';
+  const isOnBottomRight = switcher.dataset.location === 'bottom-right';
+  const isRTL = document.body.dir === 'rtl'
+
+  // Stuck on the left side of the switcher.
+  let x = switcherRect.left;
+
+  if (isOnTop && !isRTL || isOnBottom && isRTL || isOnBottomRight && !isRTL) {
+    // Stuck on the right side of the switcher.
+    x = switcherRect.right - optionsElement.clientWidth;
+  }
+
+  // Stuck on the top of the switcher.
+  let y = switcherRect.top - window.innerHeight - 15;
+
+  if (isOnTop) {
+    // Stuck on the bottom of the switcher.
+    y = switcherRect.top - window.innerHeight + optionsElement.clientHeight + switcher.clientHeight + 10;
+  }
+
+  return { x: x, y: y };
+}
+
+function toggleMenu(switcher) {
+  const optionsElement = switcher.nextElementSibling;
+
+  optionsElement.classList.toggle('hx:hidden');
+
+  // Calculate the position of a language options element.
+  const translate = computeMenuTranslation(switcher, optionsElement);
+
+  optionsElement.style.transform = `translate3d(${translate.x}px, ${translate.y}px, 0)`;
+}
+
+function resizeMenu(switcher) {
+  const optionsElement = switcher.nextElementSibling;
+
+  if (optionsElement.classList.contains('hx:hidden')) return;
+
+  // Calculate the position of a language options element.
+  const translate = computeMenuTranslation(switcher, optionsElement);
+
+  optionsElement.style.transform = `translate3d(${translate.x}px, ${translate.y}px, 0)`;
+}

--- a/assets/js/switcher-menu.js
+++ b/assets/js/switcher-menu.js
@@ -19,7 +19,7 @@ function computeMenuTranslation(switcher, optionsElement) {
   }
 
   // Stuck on the top of the switcher.
-  let y = switcherRect.top - window.innerHeight - 15;
+  let y = switcherRect.top - window.innerHeight - 10;
 
   if (isOnTop) {
     // Stuck on the bottom of the switcher.

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -36,41 +36,11 @@
     toggler.addEventListener("click", function (e) {
       e.preventDefault();
 
-      const optionsElement = toggler.nextElementSibling;
-
-      optionsElement.classList.toggle('hx:hidden');
-
-      // Calculate the position of a language options element.
-      const switcherRect = toggler.getBoundingClientRect();
-
-      // Must be called before optionsElement.clientWidth.
-      optionsElement.style.minWidth = `${Math.max(switcherRect.width, 50)}px`;
-
-      const isOnTop = toggler.dataset.location === 'top';
-      const isOnBottom = toggler.dataset.location === 'bottom';
-      const isOnBottomRight = toggler.dataset.location === 'bottom-right';
-      const isRTL = document.body.dir === 'rtl'
-
-      // Stuck on the left side of the switcher.
-      let translateX = switcherRect.left;
-
-      if (isOnTop && !isRTL || isOnBottom && isRTL || isOnBottomRight && !isRTL) {
-        // Stuck on the right side of the switcher.
-        translateX = switcherRect.right - optionsElement.clientWidth;
-      }
-
-      // Stuck on the top of the switcher.
-      let translateY = switcherRect.top - window.innerHeight - 15;
-
-      if (isOnTop) {
-        // Stuck on the bottom of the switcher.
-        translateY = switcherRect.top - window.innerHeight + optionsElement.clientHeight + toggler.clientHeight + 10;
-      }
-
-      optionsElement.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
+      toggleMenu(toggler);
     });
   });
 
+  window.addEventListener("resize", () => themeToggleButtons.forEach(resizeMenu))
 
   // Dismiss the menu when clicking outside
   document.addEventListener('click', (e) => {

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -64,7 +64,7 @@
 
       if (isOnTop) {
         // Stuck on the bottom of the switcher.
-        translateY = switcherRect.top - window.innerHeight + 150;
+        translateY = switcherRect.top - window.innerHeight + optionsElement.clientHeight + toggler.clientHeight + 10;
       }
 
       optionsElement.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;

--- a/layouts/_partials/scripts/core.html
+++ b/layouts/_partials/scripts/core.html
@@ -1,3 +1,4 @@
+{{- $jsSwitcherMenu := resources.Get "js/switcher-menu.js" -}}
 {{- $jsTheme := resources.Get "js/theme.js" | resources.ExecuteAsTemplate "theme.js" . -}}
 {{- $jsBanner := resources.Get "js/banner.js" | resources.ExecuteAsTemplate "banner.js" . -}}
 {{- $jsMenu := resources.Get "js/menu.js" -}}
@@ -11,7 +12,7 @@
 {{- $jsTocScroll := resources.Get "js/toc-scroll.js" -}}
 {{- $jsFavicon := resources.Get "js/favicon.js" | resources.ExecuteAsTemplate "favicon.js" . -}}
 
-{{- $scripts := slice $jsTheme $jsBanner $jsMenu $jsCodeCopy $jsTabs $jsLang $jsNavMenu $jsFileTree $jsSidebar $jsBackToTop $jsTocScroll $jsFavicon | resources.Concat "js/main.js" -}}
+{{- $scripts := slice $jsSwitcherMenu $jsTheme $jsBanner $jsMenu $jsCodeCopy $jsTabs $jsLang $jsNavMenu $jsFileTree $jsSidebar $jsBackToTop $jsTocScroll $jsFavicon | resources.Concat "js/main.js" -}}
 {{- if hugo.IsProduction -}}
   {{- $scripts = $scripts | minify | fingerprint -}}
 {{- end -}}


### PR DESCRIPTION
Fixes https://github.com/imfing/hextra/pull/760#issuecomment-3235750433


<details>
<summary>2 items</summary>
<img width="422" height="388" alt="Screenshot 2025-08-29 at 10-13-31 Cards Component – Hextra" src="https://github.com/user-attachments/assets/4b3a9eb8-83cd-4cee-9bb5-9e7727226d02" />
</details>

<details>
<summary>3 items</summary>
<img width="450" height="466" alt="Screenshot 2025-08-29 at 10-13-07 Cards Component – Hextra" src="https://github.com/user-attachments/assets/5afef2e0-6989-4a79-990e-305c1a25f117" />
</details>

<details>
<summary>4 items</summary>
<img width="518" height="472" alt="Screenshot 2025-08-29 at 10-13-58 Cards Component – Hextra" src="https://github.com/user-attachments/assets/44ee3031-d9a8-4c67-9c17-b4d959d01d98" />
</details>

I also changed the theme switcher position: now the 2 menus are at the same position on top.
And I handled the resize of the window.

It can be tried by adding this configuration:
```yml

    - name: Lang
      weight: 8
      params:
        type: language-switch
    - name: theme
      weight: 9
      params:
        type: theme-toggle
```

Tested with RTL/LTR on Desktop and mobile.