### PR TITLE
fix: move dir attribute to html tag

### DIFF
--- a/assets/js/switcher-menu.js
+++ b/assets/js/switcher-menu.js
@@ -8,7 +8,7 @@ function computeMenuTranslation(switcher, optionsElement) {
   const isOnTop = switcher.dataset.location === 'top';
   const isOnBottom = switcher.dataset.location === 'bottom';
   const isOnBottomRight = switcher.dataset.location === 'bottom-right';
-  const isRTL = document.body.dir === 'rtl'
+  const isRTL = document.documentElement.dir === 'rtl'
 
   // Stuck on the left side of the switcher.
   let x = switcherRect.left;

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}">
+<html lang="{{ .Site.Language.Lang }}" dir="{{ .Site.Language.LanguageDirection | default `ltr` }}">
   {{- partial "head.html" . -}}
-  <body dir="{{ .Site.Language.LanguageDirection | default `ltr` }}">
+  <body>
     {{- partial "banner.html" . -}}
     {{- partial "navbar.html" . -}}
     {{- block "main" . }}{{ end -}}


### PR DESCRIPTION
Moves `dir` from `body` to `html`.


<img width="1990" height="132" alt="Screenshot_20250829_114819" src="https://github.com/user-attachments/assets/76fd5e6c-c444-4f45-bd11-795a556f5c47" />

> When rendering the <html> element, the used values of CSS properties “writing-mode”, “direction”, and “text-orientation” on the <html> element are taken from the computed values of the <body> element, not from the <html> element’s own values. Consider setting these properties on the :root CSS pseudo-class. For more information see “The Principal Writing Mode” in https://www.w3.org/TR/css-writing-modes-3/#principal-flow
