### PR TITLE
fix(tags): update tag link to use the correct tag title instead of page title

### DIFF
--- a/layouts/_partials/tags.html
+++ b/layouts/_partials/tags.html
@@ -2,6 +2,6 @@
 
 {{- range $tag := $context.Params.tags -}}
   {{- with $context.Site.GetPage (printf "/tags/%s" $tag) -}}
-    <a class="hx:inline-block hx:whitespace-nowrap hx:mr-2 hx:text-gray-500 hx:hover:text-gray-900 hx:dark:text-gray-400 hx:dark:hover:text-gray-100 hx:contrast-more:text-gray-800 hx:contrast-more:dark:text-gray-50" href="{{ .RelPermalink }}">#{{ .Title }}</a>
+    <a class="hx:inline-block hx:whitespace-nowrap hx:mr-2 hx:text-gray-500 hx:hover:text-gray-900 hx:dark:text-gray-400 hx:dark:hover:text-gray-100 hx:contrast-more:text-gray-800 hx:contrast-more:dark:text-gray-50" href="{{ .RelPermalink }}">#{{ $tag }}</a>
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
the tags were using `.Title` which automatically gets `capitalized and pluralized`

https://gohugo.io/methods/page/title/#article