### PR TITLE
Hextra shortcodes not in sidebar / fixed

### DIFF
--- a/docs/content/docs/guide/shortcodes/hextra.fa.md
+++ b/docs/content/docs/guide/shortcodes/hextra.fa.md
@@ -1,8 +1,6 @@
 ---
 title: Hextra Shortcodes
 linkTitle: Hextra
-sidebar:
-  exclude: true
 next: /docs/guide/deploy-site
 ---
 

--- a/docs/content/docs/guide/shortcodes/hextra.ja.md
+++ b/docs/content/docs/guide/shortcodes/hextra.ja.md
@@ -1,8 +1,6 @@
 ---
 title: Hextra Shortcodes
 linkTitle: Hextra
-sidebar:
-  exclude: true
 next: /docs/guide/deploy-site
 ---
 

--- a/docs/content/docs/guide/shortcodes/hextra.md
+++ b/docs/content/docs/guide/shortcodes/hextra.md
@@ -1,8 +1,6 @@
 ---
 title: Hextra Shortcodes
 linkTitle: Hextra
-sidebar:
-  exclude: true
 next: /docs/guide/deploy-site
 ---
 

--- a/docs/content/docs/guide/shortcodes/hextra.zh-cn.md
+++ b/docs/content/docs/guide/shortcodes/hextra.zh-cn.md
@@ -1,8 +1,6 @@
 ---
 title: Hextra Shortcodes
 linkTitle: Hextra
-sidebar:
-  exclude: true
 next: /docs/guide/deploy-site
 ---
 


### PR DESCRIPTION
That hextra-shortcodes are not in the sidebar. 
This is annoying, when you are working on a project, because you can only find it through the search.

