### PR TITLE
Feature: disable next/previous pagination buttons site-wide

### DIFF
--- a/docs/content/docs/guide/configuration.md
+++ b/docs/content/docs/guide/configuration.md
@@ -128,6 +128,16 @@ params:
       height: 20
 ```
 
+### Pagination
+
+Hextra can render previous/next navigation at the bottom of content pages (for example, in docs and blog articles) to help readers move between pages in the same section. You can disable this site-wide with a single setting:
+
+```yaml {filename="hugo.yaml"}
+params:
+  page:
+    displayPagination: false
+```
+
 ## Sidebar
 
 ### Main Sidebar

--- a/layouts/_partials/components/pager.html
+++ b/layouts/_partials/components/pager.html
@@ -1,5 +1,6 @@
 {{/* Article navigation on the footer of the article */}}
 
+{{- if (site.Params.page.displayPagination | default true) -}}
 {{- $reversePagination := .Store.Get "reversePagination" | default false -}}
 
 {{- $prev := cond $reversePagination .PrevInSection .NextInSection -}}
@@ -50,4 +51,5 @@
       </a>
     {{- end -}}
   </div>
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
Disable Site-Wide Prev/Next Pagination in Hugo
This feature allows disabling the previous/next navigation buttons site-wide by setting params.page.displayPagination to false in hugo.yaml. It helps control pagination display easily across docs and blog articles.

Thank you for considering this!