### PR TITLE
fix(docs): menu main duplicate field

### DIFF
--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -116,7 +116,6 @@ menu:
       params:
         type: link
         icon: beaker
-      parent: versions
     - identifier: v0.10
       name: v0.10 ↗
       url: https://imfing.github.io/hextra/versions/v0.10/


### PR DESCRIPTION
The field `parent` is duplicated.

Related to https://github.com/imfing/hextra/pull/813/files#diff-d5c956de42afb7f74e802a33282d709f17378a82367268f07ca3f0fa0ec121d0R123