### PR TITLE
Markdown attribute support for headers + "no-step-marker" docs for steps

### DIFF
--- a/docs/content/docs/guide/shortcodes/steps.md
+++ b/docs/content/docs/guide/shortcodes/steps.md
@@ -4,6 +4,8 @@ title: Steps
 
 A built-in component to display a series of steps.
 
+You can use the Markdown attribute `{class="no-step-marker"}` to prevent a heading from being counted as a step.
+
 ## Example
 
 {{% steps %}}
@@ -15,6 +17,10 @@ This is the first step.
 ### Step 2
 
 This is the second step.
+
+#### Step subheading {class="no-step-marker"}
+
+This will not be counted as a step.
 
 ### Step 3
 
@@ -42,6 +48,10 @@ This is the first step.
 ### Step 2
 
 This is the second step.
+
+#### Step subheading {class="no-step-marker"}
+
+This will not be counted as a step.
 
 {{%/* /steps */%}}
 ```

--- a/docs/hugo_stats.json
+++ b/docs/hugo_stats.json
@@ -715,6 +715,7 @@
       "msupsub",
       "mtable",
       "mtight",
+      "no-step-marker",
       "not-prose",
       "nulldelimiter",
       "op-symbol",

--- a/layouts/_markup/render-heading.html
+++ b/layouts/_markup/render-heading.html
@@ -1,4 +1,4 @@
-<h{{ .Level }}>
+<h{{ .Level }} {{- with .Attributes.class }} class="{{ . }}" {{- end }}>
   {{- .Text | safeHTML -}}
   {{- if gt .Level 1 -}}
     <span class="hx:absolute hx:-mt-20" id="{{ .Anchor | safeURL }}"></span>


### PR DESCRIPTION
I added the ability to specify HTML classes for headings via [markdown attributes](https://gohugo.io/render-hooks/headings/#examples).

This also enables the use of the existing `no-step-marker` class when using the steps shortcode, which allows for subheadings to be used without incrementing the step counter. I added docs about this.

This handles #850 which I opened earlier. 😁