### PR TITLE
Stripping `HAHAHUGOSHORTCODExxxx` in toc.html when icons are used in headings

### DIFF
--- a/layouts/_partials/toc.html
+++ b/layouts/_partials/toc.html
@@ -79,7 +79,7 @@
     {{- if .Title }}
       <li class="hx:my-2 hx:scroll-my-6 hx:scroll-py-6">
         <a class="{{ $class }} hx:inline-block hx:text-gray-500 hx:hover:text-gray-900 hx:dark:text-gray-400 hx:dark:hover:text-gray-300 hx:contrast-more:text-gray-900 hx:contrast-more:underline hx:contrast-more:dark:text-gray-50 hx:w-full hx:break-words" href="#{{ anchorize .ID }}">
-          {{- .Title | safeHTML | plainify | htmlUnescape }}
+          {{- replaceRE "HAHAHUGOSHORTCODE[0-9a-zA-Z]+HBHB" "" (.Title | safeHTML | plainify | htmlUnescape) }}gi
         </a>
       </li>
     {{- end -}}


### PR DESCRIPTION
This is a very quick fix to remove icon shortcodes from rendering as `HAHAHUGOSHORTCODExxxx` on the table of contents on the right hand side of the page. This PR should temporarily strip this until a better solution to actually render the icon properly is devised.