### PR TITLE
fix(card): ensure subtitle stays at bottom by wrapping title/subtitle…

### DIFF
--- a/layouts/_partials/shortcodes/card.html
+++ b/layouts/_partials/shortcodes/card.html
@@ -46,7 +46,7 @@
     {{- $padding = "hx:pt-4 hx:px-4" -}}
   {{- end -}}
 
-  <div style="margin-top: auto;">
+  <div class="hx:mt-auto">
     <span class="hextra-card-icon hx:flex hx:font-semibold hx:items-start hx:gap-2 {{ $padding }} hx:text-gray-700 hx:hover:text-gray-900 hx:dark:text-neutral-200 hx:dark:hover:text-neutral-50">
       {{- with $icon }}{{ partial "utils/icon.html" (dict "name" $icon) -}}{{- end -}}
       {{- $title -}}


### PR DESCRIPTION
This PR updates the Hextra card layout so that the title and subtitle consistently appear at the bottom of the card, regardless of content height.

I keep the implementation simple by wrapping the existing title and subtitle block inside a container with ```margin-top: auto```.

**Before**
When cards with different image heights were displayed using the **cards** shortcode, cards with smaller images had the title and subtitle positioned immediately below the image, leaving an awkward empty gap at the bottom of the card.

**After**
Cards now automatically align the title and subtitle at the bottom, resulting in a more consistent appearance across the theme.