### PR TITLE
fix: respect `search.enable` in the mobile

### DIFF
--- a/layouts/_partials/sidebar.html
+++ b/layouts/_partials/sidebar.html
@@ -21,10 +21,12 @@
 {{- end -}}
 
 <aside class="hextra-sidebar-container hx:flex hx:flex-col hx:print:hidden hx:md:top-16 hx:md:shrink-0 hx:md:w-64 hx:md:self-start hx:max-md:[transform:translate3d(0,-100%,0)] {{ $sidebarClass }}">
-  <!-- Search bar on small screen -->
-  <div class="hx:px-4 hx:pt-4 hx:md:hidden">
-    {{ partial "search.html" }}
-  </div>
+  {{- if (site.Params.search.enable | default true) -}}
+    <!-- Search bar on small screen -->
+    <div class="hx:px-4 hx:pt-4 hx:md:hidden">
+      {{ partial "search.html" }}
+    </div>
+  {{- end -}}
   <div class="hextra-scrollbar hx:overflow-y-auto hx:overflow-x-hidden hx:p-4 hx:grow hx:md:h-[calc(100vh-var(--navbar-height)-var(--menu-height))]">
     <ul class="hx:flex hx:flex-col hx:gap-1 hx:md:hidden">
       <!-- Nav -->


### PR DESCRIPTION
The sidebar displays the search box regardless of the `search.enable` setting.

When `search.enable` is false, the search box is still displayed, but the related scripts are not loaded:
https://github.com/imfing/hextra/blob/a9ef7ad57dcf2a04d7e85691c58b840b9e52163f/layouts/_partials/scripts/search.html#L2-L26