### PR TITLE
fix: respect the page parameter `toc` in the mobile dropdown

### DIFF
--- a/layouts/_partials/sidebar.html
+++ b/layouts/_partials/sidebar.html
@@ -90,7 +90,7 @@
           <li class="{{ if $shouldOpen }}open{{ end }}">
             {{- $linkTitle := partial "utils/title" . -}}
             {{- template "sidebar-item-link" dict "context" . "active" $active "title" $linkTitle "link" .RelPermalink -}}
-            {{- if and $toc $active -}}
+            {{- if and $toc $active (ne .Params.toc false) -}}
               {{- template "sidebar-toc" dict "page" . -}}
             {{- end -}}
             {{- template "sidebar-tree" dict "context" . "page" $page "pageURL" $pageURL "level" (add $level 1) "toc" $toc -}}
@@ -106,7 +106,7 @@
             {{- $linkTitle := partial "utils/title" . -}}
             <li class="hx:flex hx:flex-col {{ if $shouldOpen }}open{{ end }}">
               {{- template "sidebar-item-link" dict "context" . "active" $active "title" $linkTitle "link" .RelPermalink -}}
-              {{- if and $toc $active -}}
+              {{- if and $toc $active (ne .Params.toc false) -}}
                 {{ template "sidebar-toc" dict "page" . }}
               {{- end }}
               {{ template "sidebar-tree" dict "context" . "page" $page "pageURL" $pageURL "level" (add $level 1) "toc" $toc }}


### PR DESCRIPTION
`toc: false` can be set for a page to disable its table of contents, the parameter is not respected in the sidebar though.

This is how a page with `toc: false` appears in a sidebar.
<img width="506" height="93" alt="image" src="https://github.com/user-attachments/assets/dbf0e27f-6883-4a5d-a909-104ef9cd0c7b" />