### PR TITLE
fix(navbar): improve active state detection for multilingual section pages

### DIFF
--- a/layouts/_partials/navbar-link.html
+++ b/layouts/_partials/navbar-link.html
@@ -5,6 +5,14 @@
 {{- $external := .external -}}
 
 {{- $active := or ($currentPage.HasMenuCurrent "main" $item) ($currentPage.IsMenuCurrent "main" $item) -}}
+{{- /* Additional check for section landing pages in multilingual sites (normalize trailing slashes) */ -}}
+{{- if and (not $active) $link -}}
+  {{- $currentPath := strings.TrimSuffix "/" $currentPage.RelPermalink -}}
+  {{- $linkPath := strings.TrimSuffix "/" $link -}}
+  {{- if eq $currentPath $linkPath -}}
+    {{- $active = true -}}
+  {{- end -}}
+{{- end -}}
 {{- $activeClass := cond $active "hx:font-medium" "hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200" -}}
 
 {{- if $item.HasChildren -}}


### PR DESCRIPTION
## Summary
- Fix navbar menu item not being highlighted on multilingual section landing pages (e.g., `/fa/docs/`)
- Add path comparison with trailing slash normalization as fallback when Hugo's `IsMenuCurrent`/`HasMenuCurrent` don't match

## Problem
Hugo's `IsMenuCurrent` and `HasMenuCurrent` functions don't reliably detect the active state for section landing pages in multilingual sites due to a trailing slash mismatch:
- `relLangURL` returns paths without trailing slash (e.g., `/fa/docs`)
- Page's `RelPermalink` includes trailing slash (e.g., `/fa/docs/`)

## Solution
Added an additional check in `navbar-link.html` that normalizes trailing slashes before comparing the current page's path with the menu link. The check only runs when the link is non-empty to avoid false matches on dropdown menus.