### PR TITLE
fix(glossary): do not list Glossary by default

### DIFF
--- a/content/glossary/_index.en.md
+++ b/content/glossary/_index.en.md
@@ -1,4 +1,7 @@
 ---
 title: Glossary
 layout: glossary
+build:
+  # This ensures the glossary won't appear in .Site.Pages, .Site.RegularPages, etc.
+  list: never
 ---

--- a/content/glossary/_index.fa.md
+++ b/content/glossary/_index.fa.md
@@ -1,4 +1,7 @@
 ---
 title: واژه‌نامه
 layout: glossary
+build:
+  # This ensures the glossary won't appear in .Site.Pages, .Site.RegularPages, etc.
+  list: never
 ---

--- a/content/glossary/_index.ja.md
+++ b/content/glossary/_index.ja.md
@@ -1,4 +1,7 @@
 ---
 title: 用語集
 layout: glossary
+build:
+  # This ensures the glossary won't appear in .Site.Pages, .Site.RegularPages, etc.
+  list: never
 ---

--- a/content/glossary/_index.zh-cn.md
+++ b/content/glossary/_index.zh-cn.md
@@ -1,4 +1,7 @@
 ---
 title: 术语表
 layout: glossary
+build:
+  # This ensures the glossary won't appear in .Site.Pages, .Site.RegularPages, etc.
+  list: never
 ---


### PR DESCRIPTION
The Glossary page used to be shown even when not used at all.