### PR TITLE
refactor(layout): keep content width fixed and document CSS var override

### DIFF
--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -2,15 +2,13 @@
 
 /* Do not remove the following comment. It is used by Hugo to render CSS variables.
 {{- $layoutWidthValues := dict "normal" "80rem" "wide" "90rem" "full" "100%" -}}
-{{- $contentWidthValues := dict "normal" "72rem" "wide" "80rem" "full" "100%" -}}
 {{- $layoutWidthDefault := index $layoutWidthValues "normal" -}}
-{{- $contentWidthDefault := index $contentWidthValues "normal" -}}
 
 {{- $maxPageWidth := (index $layoutWidthValues (site.Params.page.width | default "normal")) | default $layoutWidthDefault -}}
 {{- $maxNavbarWidth := (index $layoutWidthValues (site.Params.navbar.width | default "normal")) | default $layoutWidthDefault -}}
 {{- $maxFooterWidth := (index $layoutWidthValues (site.Params.footer.width | default "normal")) | default $layoutWidthDefault -}}
 
-{{- $maxContentWidth := (index $contentWidthValues (site.Params.page.content.width | default "normal")) | default $contentWidthDefault -}}
+{{- $maxContentWidth := "72rem" -}}
 */
 
 :root {

--- a/docs/content/docs/guide/configuration.fa.md
+++ b/docs/content/docs/guide/configuration.fa.md
@@ -342,23 +342,26 @@ params:
 
 ### عرض صفحه
 
-عرض پوستهٔ صفحه را می‌توان با پارامتر `params.page.width` تنظیم کرد و عرض محتوای اصلی را می‌توان جداگانه با `params.page.content.width` کنترل کرد:
+عرض پوستهٔ صفحه را می‌توان با پارامتر `params.page.width` تنظیم کرد:
 
 ```yaml {filename="hugo.yaml"}
 params:
   page:
     # full (100%), wide (90rem), normal (1280px)
     width: wide
-    content:
-      # normal (72rem), wide (80rem), full (100%)
-      width: normal
 ```
 
 گزینه‌های `params.page.width`: `full`، `wide`، و `normal`.
 
-گزینه‌های `params.page.content.width`: `normal`، `wide`، و `full`.
+عرض محتوای اصلی به صورت پیش‌فرض روی `72rem` ثابت است.
 
-به طور پیش‌فرض هر دو مقدار `normal` هستند.
+برای سفارشی‌سازی عرض محتوا، متغیر CSS را در فایل استایل سفارشی خود بازنویسی کنید:
+
+```css {filename="assets/css/custom.css"}
+:root {
+  --hextra-max-content-width: 100%;
+}
+```
 
 به طور مشابه، عرض نوار ناوبری و پاورقی را می‌توان با پارامترهای `params.navbar.width` و `params.footer.width` سفارشی کرد.
 

--- a/docs/content/docs/guide/configuration.ja.md
+++ b/docs/content/docs/guide/configuration.ja.md
@@ -342,23 +342,26 @@ params:
 
 ### ページ幅
 
-レイアウト全体の幅は `params.page.width` で、本文コンテンツ幅は `params.page.content.width` で個別に設定できます：
+レイアウト全体の幅は `params.page.width` で設定できます：
 
 ```yaml {filename="hugo.yaml"}
 params:
   page:
     # full (100%), wide (90rem), normal (1280px)
     width: wide
-    content:
-      # normal (72rem), wide (80rem), full (100%)
-      width: normal
 ```
 
 `params.page.width` の選択肢は `full`、`wide`、`normal` です。
 
-`params.page.content.width` の選択肢は `normal`、`wide`、`full` です。
+本文コンテンツ幅はデフォルトで `72rem` に固定されています。
 
-デフォルトはどちらも `normal` です。
+コンテンツ幅を変更したい場合は、カスタムスタイルシートで CSS 変数を上書きしてください：
+
+```css {filename="assets/css/custom.css"}
+:root {
+  --hextra-max-content-width: 100%;
+}
+```
 
 同様に、ナビゲーションバーとフッターの幅は `params.navbar.width` と `params.footer.width` パラメータでカスタマイズできます。
 

--- a/docs/content/docs/guide/configuration.md
+++ b/docs/content/docs/guide/configuration.md
@@ -364,23 +364,26 @@ params:
 
 ### Page Width
 
-The layout shell width can be customized by the `params.page.width` parameter in the config file, and the main reading content width can be customized separately with `params.page.content.width`:
+The layout shell width can be customized by the `params.page.width` parameter in the config file:
 
 ```yaml {filename="hugo.yaml"}
 params:
   page:
     # full (100%), wide (90rem), normal (1280px)
     width: wide
-    content:
-      # normal (72rem), wide (80rem), full (100%)
-      width: normal
 ```
 
 Available options for `params.page.width`: `full`, `wide`, `normal`.
 
-Available options for `params.page.content.width`: `normal`, `wide`, `full`.
+The main reading content width remains fixed at `72rem` by default.
 
-By default, both are set to `normal`.
+To customize content width, override the CSS variable in your custom stylesheet:
+
+```css {filename="assets/css/custom.css"}
+:root {
+  --hextra-max-content-width: 100%;
+}
+```
 
 Similarly, the width of the navbar and footer can be customized by the `params.navbar.width` and `params.footer.width` parameters.
 

--- a/docs/content/docs/guide/configuration.zh-cn.md
+++ b/docs/content/docs/guide/configuration.zh-cn.md
@@ -342,23 +342,26 @@ params:
 
 ### 页面宽度
 
-页面整体布局宽度可通过 `params.page.width` 配置，正文内容宽度可通过 `params.page.content.width` 单独配置：
+页面整体布局宽度可通过 `params.page.width` 配置：
 
 ```yaml {filename="hugo.yaml"}
 params:
   page:
     # full (100%), wide (90rem), normal (1280px)
     width: wide
-    content:
-      # normal (72rem), wide (80rem), full (100%)
-      width: normal
 ```
 
 `params.page.width` 可用选项：`full`、`wide`、`normal`。
 
-`params.page.content.width` 可用选项：`normal`、`wide`、`full`。
+正文内容宽度默认固定为 `72rem`。
 
-默认情况下二者都为 `normal`。
+如需自定义内容宽度，请在自定义样式表中覆盖 CSS 变量：
+
+```css {filename="assets/css/custom.css"}
+:root {
+  --hextra-max-content-width: 100%;
+}
+```
 
 类似地，导航栏和页脚的宽度可以通过 `params.navbar.width` 和 `params.footer.width` 参数自定义。
 

--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -258,9 +258,6 @@ params:
   page:
     # full (100%), wide (90rem), normal (80rem)
     width: normal
-    content:
-      # normal (72rem), wide (80rem), full (100%)
-      width: normal
     # tabs:
     #   sync: true
     contextMenu:


### PR DESCRIPTION
## Summary
- keep main reading content width fixed at `72rem` by default
- keep `params.page.width` for layout shell width only
- document `--hextra-max-content-width` as the customization escape hatch
- update width docs in EN/FA/JA/ZH-CN and docs config example

## Why
Following #911, making content width follow page width created overly wide reading layouts in common cases. This restores a safer default while still allowing customization through CSS variables.

## Related
- Previous PR that introduced the behavior: #911
- Original issue context: #886
