### PR TITLE
fix: greedy trim

### DIFF
--- a/layouts/page.markdown.md
+++ b/layouts/page.markdown.md
@@ -1,3 +1,2 @@
-{{- .Title | replaceRE "\n" " " | printf "# %s" -}}
-
+{{- .Title | replaceRE "\n" " " | printf "# %s" }}
 {{ .RawContent }}

--- a/layouts/section.markdown.md
+++ b/layouts/section.markdown.md
@@ -1,3 +1,2 @@
-{{- .Title | replaceRE "\n" " " | printf "# %s" -}}
-
+{{- .Title | replaceRE "\n" " " | printf "# %s" }}
 {{ .RawContent }}


### PR DESCRIPTION
## Objective

Here's the issue:

1. {{- on line 1 trims any whitespace before the action - clean start
2. The action outputs # Introduction
3. -}} on line 1 trims all whitespace after the action - this is the problem

The -}} doesn't just trim to end of line 1. It's greedy - it consumes:

- the newline at end of line 1
- the entire blank line 2 (which is just a \n)
- the newline at end of line 2

Before fix, https://imfing.github.io/hextra/docs/ `Copy Page` renders incorrect markdown:

```
# Introduction
👋 Hello! Welcome to the Hextra documentation!

<!--more-->
```

After fix, the correct markdown is rendered:

```
# Introduction

👋 Hello! Welcome to the Hextra documentation!

<!--more-->
```

## Scope

- [x] Bug (resolves an issue)
- [ ] Enhancement (improves existing functionality)
- [ ] Feature (adds new functionality)
- [ ] Documentation (adds or improves documentation)

### Impact

- [x] Non-breaking (backwards compatible)
- [ ] Breaking (backwards incompatible, impacts end-user)

## Checklist

- [x] My code follows the contributing guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new issues or warnings
