### PR TITLE
Fix deprecation warning

### DIFF
--- a/assets/json/search-data.json
+++ b/assets/json/search-data.json
@@ -20,7 +20,7 @@
 
 {{/* Extract glossary data entries */}}
 {{- $glossaryEntries := dict -}}
-{{- with (index .Site.Data .Site.Language.Lang "termbase") -}}
+{{- with (index hugo.Data .Site.Language.Lang "termbase") -}}
   {{- range . -}}
     {{- $entry := cond (.abbr) (printf "%s %s %s" .abbr .term .definition) (printf "%s %s" .term .definition) -}}
     {{- $glossaryEntries = $glossaryEntries | merge (dict .term $entry) -}}

--- a/layouts/_partials/utils/icon.html
+++ b/layouts/_partials/utils/icon.html
@@ -1,5 +1,5 @@
-{{/* Render raw svg icon from .Site.Data */}}
-{{- $icon := index site.Data.icons .name -}}
+{{/* Render raw svg icon from hugo.Data */}}
+{{- $icon := index hugo.Data.icons .name -}}
 
 {{- if not $icon -}}
   {{ errorf "icon %q not found" .name }}

--- a/layouts/_partials/utils/lang-link.html
+++ b/layouts/_partials/utils/lang-link.html
@@ -13,7 +13,7 @@
 {{ end }}
 
 {{ if not $link }}
-  {{ range where $page.Sites ".Language.Lang" $lang }}
+  {{ range where hugo.Sites ".Language.Lang" $lang }}
     {{ $link = .Home.RelPermalink }}
   {{ end }}
 {{ end }}

--- a/layouts/_shortcodes/icon.html
+++ b/layouts/_shortcodes/icon.html
@@ -13,7 +13,7 @@ or
 */ -}}
 
 {{- $name := .Get "name" | default (.Get 0) -}}
-{{- $icon := index site.Data.icons $name -}}
+{{- $icon := index hugo.Data.icons $name -}}
 {{- $attributes := .Get "attributes" | default "height=1em"}}
 
 {{- if not $icon -}}

--- a/layouts/_shortcodes/term.html
+++ b/layouts/_shortcodes/term.html
@@ -16,7 +16,7 @@ or
 {{- $match := dict -}}
 
 <!-- Go over the term data file - data/<lang>/termbase.yaml -->
-{{- range (index .Site.Data .Site.Language.Lang "termbase") -}}
+{{- range (index hugo.Data .Site.Language.Lang "termbase") -}}
   {{- if or (eq (lower .abbr) $entryLower) (eq (lower .term) $entryLower) -}}
     {{- $match = . -}}
     {{- break -}}

--- a/layouts/glossary.html
+++ b/layouts/glossary.html
@@ -6,7 +6,7 @@
       <main id="content" class="hx:w-full hx:min-w-0 hextra-max-content-width hx:px-6 hx:pt-4 hx:md:px-12">
         {{ if .Title }}<h1 class="hx:text-center hx:mt-2 hx:text-4xl hx:font-bold hx:tracking-tight hx:text-slate-900 hx:dark:text-slate-100">{{ .Title }}</h1>{{ end }}
         <div class="content">
-          {{- with (index .Site.Data .Site.Language.Lang "termbase") -}}
+          {{- with (index hugo.Data .Site.Language.Lang "termbase") -}}
           <dl>
             {{- range sort . "term" -}}
             <dt>


### PR DESCRIPTION
When previewing the theme, deprecation warnings are shown with latest released hugo version 0.157.0:

````
INFO  deprecated: .Site.Data was deprecated in Hugo v0.156.0 and will be removed in a future release.
Use hugo.Data instead.
INFO  deprecated: .Site.Sites and .Page.Sites was deprecated in Hugo v0.156.0 and will be removed in a future release.
Use hugo.Sites instead.
````
 This PR fixes that issue.

**Note:**: This PR raises the minimum required hugo version to `0.156.0`.