### PR TITLE
docs(showcase): add Sortie

### DIFF
--- a/docs/content/showcase/index.fa.md
+++ b/docs/content/showcase/index.fa.md
@@ -31,4 +31,5 @@ layout: wide
   {{< card link="https://lutheranconfessions.org/" title="LutheranConfessions" image="https://github.com/imfing/hextra/assets/5097752/ad6625e4-88cd-4cad-b102-5399997d0359" imageStyle="object-fit:cover; aspect-ratio:16/9;" >}}
   {{< card link="https://github.com/imfing/hextra-starter-template/" title="Hextra Starter Template" image="https://user-images.githubusercontent.com/5097752/263551418-c403b9a9-a76c-47a6-8466-513d772ef0b7.jpg" imageStyle="object-fit:cover; aspect-ratio:16/9;" >}}
   {{< card link="https://developers.clever-cloud.com/" title="Clever Cloud Documentation" image="https://cellar-c2.services.clever-cloud.com/documentation/doc-screenshot.png" imageStyle="object-fit:cover; aspect-ratio:16/9;" >}}
+  {{< card link="https://docs.sortie-ai.com" title="Sortie" image="https://raw.githubusercontent.com/sortie-ai/docs/refs/heads/main/static/img/screenshot.png" imageStyle="object-fit:cover; aspect-ratio:16/9;" >}}
 {{< /cards >}}

--- a/docs/content/showcase/index.fa.md
+++ b/docs/content/showcase/index.fa.md
@@ -12,6 +12,7 @@ layout: wide
 </p>
 
 {{< cards >}}
+  {{< card link="https://docs.sortie-ai.com" title="Sortie" image="https://raw.githubusercontent.com/sortie-ai/docs/refs/heads/main/static/img/screenshot.png" imageStyle="object-fit:cover; aspect-ratio:16/9;" >}}
   {{< card
         link="https://printn.dev"
         title="PrintN"
@@ -31,5 +32,4 @@ layout: wide
   {{< card link="https://lutheranconfessions.org/" title="LutheranConfessions" image="https://github.com/imfing/hextra/assets/5097752/ad6625e4-88cd-4cad-b102-5399997d0359" imageStyle="object-fit:cover; aspect-ratio:16/9;" >}}
   {{< card link="https://github.com/imfing/hextra-starter-template/" title="Hextra Starter Template" image="https://user-images.githubusercontent.com/5097752/263551418-c403b9a9-a76c-47a6-8466-513d772ef0b7.jpg" imageStyle="object-fit:cover; aspect-ratio:16/9;" >}}
   {{< card link="https://developers.clever-cloud.com/" title="Clever Cloud Documentation" image="https://cellar-c2.services.clever-cloud.com/documentation/doc-screenshot.png" imageStyle="object-fit:cover; aspect-ratio:16/9;" >}}
-  {{< card link="https://docs.sortie-ai.com" title="Sortie" image="https://raw.githubusercontent.com/sortie-ai/docs/refs/heads/main/static/img/screenshot.png" imageStyle="object-fit:cover; aspect-ratio:16/9;" >}}
 {{< /cards >}}

--- a/docs/content/showcase/index.ja.md
+++ b/docs/content/showcase/index.ja.md
@@ -13,6 +13,13 @@ Hextra で構築されたオープンソースプロジェクト
 
 {{< cards >}}
   {{< card
+        link="https://docs.sortie-ai.com"
+        title="Sortie"
+        image="https://raw.githubusercontent.com/sortie-ai/docs/refs/heads/main/static/img/screenshot.png"
+        imageStyle="object-fit:cover; aspect-ratio:16/9;"
+  >}}
+
+  {{< card
         link="https://printn.dev"
         title="PrintN"
         image="https://raw.githubusercontent.com/printn/printn.github.io/refs/heads/main/static/images/screenshot.png"
@@ -133,13 +140,6 @@ Hextra で構築されたオープンソースプロジェクト
         link="https://github.com/imfing/hextra-starter-template/"
         title="Hextra Starter Template"
         image="https://user-images.githubusercontent.com/5097752/263551418-c403b9a9-a76c-47a6-8466-513d772ef0b7.jpg"
-        imageStyle="object-fit:cover; aspect-ratio:16/9;"
-  >}}
-
-  {{< card
-        link="https://docs.sortie-ai.com"
-        title="Sortie"
-        image="https://raw.githubusercontent.com/sortie-ai/docs/refs/heads/main/static/img/screenshot.png"
         imageStyle="object-fit:cover; aspect-ratio:16/9;"
   >}}
 

--- a/docs/content/showcase/index.ja.md
+++ b/docs/content/showcase/index.ja.md
@@ -136,4 +136,11 @@ Hextra で構築されたオープンソースプロジェクト
         imageStyle="object-fit:cover; aspect-ratio:16/9;"
   >}}
 
+  {{< card
+        link="https://docs.sortie-ai.com"
+        title="Sortie"
+        image="https://raw.githubusercontent.com/sortie-ai/docs/refs/heads/main/static/img/screenshot.png"
+        imageStyle="object-fit:cover; aspect-ratio:16/9;"
+  >}}
+
 {{< /cards >}}

--- a/docs/content/showcase/index.md
+++ b/docs/content/showcase/index.md
@@ -13,6 +13,13 @@ Open source projects powered by Hextra
 
 {{< cards >}}
   {{< card
+        link="https://docs.sortie-ai.com"
+        title="Sortie"
+        image="https://raw.githubusercontent.com/sortie-ai/docs/refs/heads/main/static/img/screenshot.png"
+        imageStyle="object-fit:cover; aspect-ratio:16/9;"
+  >}}
+
+  {{< card
         link="https://printn.dev"
         title="PrintN"
         image="https://raw.githubusercontent.com/printn/printn.github.io/refs/heads/main/static/images/screenshot.png"
@@ -133,13 +140,6 @@ Open source projects powered by Hextra
         link="https://github.com/imfing/hextra-starter-template/"
         title="Hextra Starter Template"
         image="https://user-images.githubusercontent.com/5097752/263551418-c403b9a9-a76c-47a6-8466-513d772ef0b7.jpg"
-        imageStyle="object-fit:cover; aspect-ratio:16/9;"
-  >}}
-
-  {{< card
-        link="https://docs.sortie-ai.com"
-        title="Sortie"
-        image="https://raw.githubusercontent.com/sortie-ai/docs/refs/heads/main/static/img/screenshot.png"
         imageStyle="object-fit:cover; aspect-ratio:16/9;"
   >}}
 

--- a/docs/content/showcase/index.md
+++ b/docs/content/showcase/index.md
@@ -136,4 +136,11 @@ Open source projects powered by Hextra
         imageStyle="object-fit:cover; aspect-ratio:16/9;"
   >}}
 
+  {{< card
+        link="https://docs.sortie-ai.com"
+        title="Sortie"
+        image="https://raw.githubusercontent.com/sortie-ai/docs/refs/heads/main/static/img/screenshot.png"
+        imageStyle="object-fit:cover; aspect-ratio:16/9;"
+  >}}
+
 {{< /cards >}}

--- a/docs/content/showcase/index.zh-cn.md
+++ b/docs/content/showcase/index.zh-cn.md
@@ -13,6 +13,13 @@ layout: wide
 
 {{< cards >}}
   {{< card
+        link="https://docs.sortie-ai.com"
+        title="Sortie"
+        image="https://raw.githubusercontent.com/sortie-ai/docs/refs/heads/main/static/img/screenshot.png"
+        imageStyle="object-fit:cover; aspect-ratio:16/9;"
+  >}}
+
+  {{< card
         link="https://printn.dev"
         title="PrintN"
         image="https://raw.githubusercontent.com/printn/printn.github.io/refs/heads/main/static/images/screenshot.png"
@@ -91,13 +98,6 @@ layout: wide
         link="https://github.com/imfing/hextra-starter-template/"
         title="Hextra Starter Template"
         image="https://user-images.githubusercontent.com/5097752/263551418-c403b9a9-a76c-47a6-8466-513d772ef0b7.jpg"
-        imageStyle="object-fit:cover; aspect-ratio:16/9;"
-  >}}
-
-  {{< card
-        link="https://docs.sortie-ai.com"
-        title="Sortie"
-        image="https://raw.githubusercontent.com/sortie-ai/docs/refs/heads/main/static/img/screenshot.png"
         imageStyle="object-fit:cover; aspect-ratio:16/9;"
   >}}
 

--- a/docs/content/showcase/index.zh-cn.md
+++ b/docs/content/showcase/index.zh-cn.md
@@ -94,4 +94,11 @@ layout: wide
         imageStyle="object-fit:cover; aspect-ratio:16/9;"
   >}}
 
+  {{< card
+        link="https://docs.sortie-ai.com"
+        title="Sortie"
+        image="https://raw.githubusercontent.com/sortie-ai/docs/refs/heads/main/static/img/screenshot.png"
+        imageStyle="object-fit:cover; aspect-ratio:16/9;"
+  >}}
+
 {{< /cards >}}


### PR DESCRIPTION
Add [Sortie](https://docs.sortie-ai.com) to the showcase.

Sortie is an open-source coding agent orchestrator. The documentation site is built with Hextra.