### PR TITLE
fix: remove inline TOC click handler so default Hextra can avoid unsafe-inline (CSP)

### DIFF
--- a/assets/js/core/back-to-top.js
+++ b/assets/js/core/back-to-top.js
@@ -3,6 +3,7 @@
 document.addEventListener("DOMContentLoaded", function () {
   const backToTop = document.querySelector("#backToTop");
   if (backToTop) {
+    backToTop.addEventListener("click", scrollUp);
     document.addEventListener("scroll", (e) => {
       if (window.scrollY > 300) {
         backToTop.classList.remove("hx:opacity-0");

--- a/layouts/_partials/toc.html
+++ b/layouts/_partials/toc.html
@@ -51,7 +51,7 @@
           <a class="hx:inline-block hx:rounded-sm hx:text-xs hx:font-medium hx:text-gray-500 hx:hover:text-gray-900 hx:dark:text-gray-400 hx:dark:hover:text-gray-100 hx:contrast-more:text-gray-800 hx:contrast-more:dark:text-gray-50 hx:hextra-focus-visible-inset" href="{{ $editURL }}" target="_blank" rel="noreferrer">{{ $editThisPage }}</a>
         {{- end -}}
         {{/* Scroll To Top */}}
-        <button id="backToTop" tabindex="-1" onClick="scrollUp();" class="hx:cursor-pointer hx:transition-all hx:duration-75 hx:opacity-0 hx:text-xs hx:font-medium hx:text-gray-500 hx:hover:text-gray-900 hx:dark:text-gray-400 hx:dark:hover:text-gray-100 hx:contrast-more:text-gray-800 hx:contrast-more:dark:text-gray-50">
+        <button id="backToTop" tabindex="-1" class="hx:cursor-pointer hx:transition-all hx:duration-75 hx:opacity-0 hx:text-xs hx:font-medium hx:text-gray-500 hx:hover:text-gray-900 hx:dark:text-gray-400 hx:dark:hover:text-gray-100 hx:contrast-more:text-gray-800 hx:contrast-more:dark:text-gray-50">
           <span>
             {{- $backToTop -}}
           </span>


### PR DESCRIPTION
## Summary
This PR removes the inline `onClick` handler from the TOC “Scroll to top” button and wires the behaviour through the existing bundled JavaScript instead.

This is a minimal CSP-focused fix that helps vanilla Hextra deployments avoid requiring `unsafe-inline` for this particular interaction.

## What Changed
- Removed the inline `onClick="scrollUp();"` from the TOC back-to-top button
- Reused the existing `assets/js/core/back-to-top.js` implementation
- Attached the click behavior with `addEventListener() `on page load

reference: https://content-security-policy.com/unsafe-hashes/ 

## Why
Inline event handlers require `unsafe-inline` under `script-src`, which makes CSP harder to lock down.

With this change, the default TOC back-to-top behavior no longer depends on inline script.

## Scope
This PR does not fully eliminate all unsafe-inline requirements across Hextra.

There are still other components that use inline scripts today, including examples such as:

- Google Analytics
- Mermaid
- MathJax
- Giscus
- Asciinema
- Medium Zoom
- Matomo
 
## Testing
Verified the TOC back-to-top button still works