### PR TITLE
fix: add Hugo compatibility helpers for deprecated multilingual APIs

### DIFF
--- a/assets/json/search-data.json
+++ b/assets/json/search-data.json
@@ -20,7 +20,8 @@
 
 {{/* Extract glossary data entries */}}
 {{- $glossaryEntries := dict -}}
-{{- with (index .Site.Data .Site.Language.Lang "termbase") -}}
+{{- $siteData := partial "utils/hugo-compat/site-data.html" . -}}
+{{- with (index $siteData .Site.Language.Lang "termbase") -}}
   {{- range . -}}
     {{- $entry := cond (.abbr) (printf "%s %s %s" .abbr .term .definition) (printf "%s %s" .term .definition) -}}
     {{- $glossaryEntries = $glossaryEntries | merge (dict .term $entry) -}}

--- a/docs/content/docs/advanced/multi-language.fa.md
+++ b/docs/content/docs/advanced/multi-language.fa.md
@@ -26,6 +26,11 @@ languages:
     weight: 3
 ```
 
+> [!NOTE]
+> از Hugo v0.158.0 به بعد، `languageName`، `languageCode` و `languageDirection` منسوخ شده‌اند.
+> برای سایت‌های جدید به‌ترتیب از `label`، `locale` و `direction` استفاده کنید.
+> مستندات [تنظیمات زبان‌های Hugo](https://gohugo.io/configuration/languages/#language-settings) را ببینید.
+
 ## مدیریت ترجمه‌ها بر اساس نام فایل
 
 هوگو از مدیریت ترجمه‌ها بر اساس نام فایل پشتیبانی می‌کند. به عنوان مثال، اگر فایلی به نام `content/docs/_index.md` به زبان انگلیسی داریم، می‌توانیم فایل `content/docs/_index.fr.md` را برای ترجمه فرانسوی ایجاد کنیم.

--- a/docs/content/docs/advanced/multi-language.ja.md
+++ b/docs/content/docs/advanced/multi-language.ja.md
@@ -26,6 +26,11 @@ languages:
     weight: 3
 ```
 
+> [!NOTE]
+> Hugo v0.158.0 以降、`languageName`、`languageCode`、`languageDirection` は非推奨です。
+> 新しいサイトでは、それぞれ `label`、`locale`、`direction` を使用してください。
+> Hugo の [言語設定ドキュメント](https://gohugo.io/configuration/languages/#language-settings)を参照してください。
+
 ## ファイル名による翻訳管理
 
 Hugo はファイル名による翻訳管理をサポートしています。例えば、英語のファイル `content/docs/_index.md` がある場合、フランス語の翻訳用に `content/docs/_index.fr.md` というファイルを作成できます。

--- a/docs/content/docs/advanced/multi-language.md
+++ b/docs/content/docs/advanced/multi-language.md
@@ -26,6 +26,11 @@ languages:
     weight: 3
 ```
 
+> [!NOTE]
+> Starting with Hugo v0.158.0, `languageName`, `languageCode`, and `languageDirection` are deprecated.
+> Use `label`, `locale`, and `direction` respectively for new sites.
+> See Hugo's [language settings documentation](https://gohugo.io/configuration/languages/#language-settings).
+
 ## Manage Translations by Filename
 
 Hugo supports managing translations by filename. For example, if we have a file `content/docs/_index.md` in English, we can create a file `content/docs/_index.fr.md` for French translation.

--- a/docs/content/docs/advanced/multi-language.zh-cn.md
+++ b/docs/content/docs/advanced/multi-language.zh-cn.md
@@ -26,6 +26,11 @@ languages:
     weight: 3
 ```
 
+> [!NOTE]
+> 从 Hugo v0.158.0 开始，`languageName`、`languageCode` 和 `languageDirection` 已被弃用。
+> 新站点请分别使用 `label`、`locale` 和 `direction`。
+> 请参阅 Hugo 的[语言设置文档](https://gohugo.io/configuration/languages/#language-settings)。
+
 ## 通过文件名管理翻译
 
 Hugo 支持通过文件名管理翻译。例如，如果我们有一个英文文件 `content/docs/_index.md`，可以创建 `content/docs/_index.fr.md` 作为法语翻译。

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang | default "en" }}" dir="{{ .Site.Language.LanguageDirection | default "ltr" }}">
+<html lang="{{ .Site.Language.Lang | default "en" }}" dir="{{ partial "utils/hugo-compat/language-direction.html" .Site.Language | default "ltr" }}">
   <body
     style='font-family:system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"; height:100vh; text-align:center; display:flex; flex-direction:column; align-items:center; justify-content:center'
   >

--- a/layouts/_partials/components/giscus.html
+++ b/layouts/_partials/components/giscus.html
@@ -1,7 +1,7 @@
 {{- $lang := site.Language.Lang | default `en` -}}
 {{- if hasPrefix $lang "zh" -}}
   {{- /* See: https://github.com/giscus/giscus/tree/main/locales */}}
-  {{- $lang = site.Language.LanguageCode | default `zh-CN` -}}
+  {{- $lang = partial "utils/hugo-compat/language-locale.html" site.Language | default `zh-CN` -}}
 {{- end -}}
 
 {{- with site.Params.comments.giscus -}}

--- a/layouts/_partials/language-switch.html
+++ b/layouts/_partials/language-switch.html
@@ -9,6 +9,8 @@
 {{- $hideLabel := .hideLabel | default false -}}
 
 {{- $changeLanguage := (T "changeLanguage") | default "Change language" -}}
+{{- $currentLanguageLang := site.Language.Lang -}}
+{{- $currentLanguageLabel := partial "utils/hugo-compat/language-label.html" site.Language -}}
 
 {{- if hugo.IsMultilingual -}}
   <div class="hx:flex hx:justify-items-start {{ if $grow }}hx:grow{{ end }}">
@@ -24,7 +26,7 @@
     >
       <div class="hx:flex hx:items-center hx:gap-2 hx:capitalize">
         {{- partial "utils/icon" (dict "name" $iconName "attributes" (printf "height=%d" $iconHeight)) -}}
-        {{- if not $hideLabel }}<span>{{ site.Language.LanguageName }}</span>{{ end -}}
+        {{- if not $hideLabel }}<span>{{ $currentLanguageLabel }}</span>{{ end -}}
       </div>
     </button>
     <ul
@@ -32,16 +34,18 @@
       style="position: fixed; inset: auto auto 0px 0px; margin: 0px; min-width: 100px;"
       role="menu"
     >
-      {{ range site.Languages }}
-        {{ $link := partial "utils/lang-link" (dict "lang" .Lang "context" $page) }}
+      {{ range partial "utils/hugo-compat/sites.html" . }}
+        {{- $language := .Language -}}
+        {{ $link := partial "utils/lang-link" (dict "lang" $language.Lang "context" $page) }}
+        {{- $languageLabel := partial "utils/hugo-compat/language-label.html" $language -}}
         <li role="none" class="hx:flex hx:flex-col">
           <a
             href="{{ $link }}"
             role="menuitem"
             class="hx:text-gray-700 hx:dark:text-gray-300 hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-neutral-800 hx:dark:hover:text-gray-100 hx:relative hx:cursor-pointer hx:whitespace-nowrap hx:rounded-sm hx:py-1.5 hx:transition-colors hx:ltr:pl-3 hx:ltr:pr-9 hx:rtl:pr-3 hx:rtl:pl-9"
           >
-            {{- .LanguageName -}}
-            {{- if eq .LanguageName site.Language.LanguageName -}}
+            {{- $languageLabel -}}
+            {{- if eq $language.Lang $currentLanguageLang -}}
               <span class="hx:absolute hx:inset-y-0 hx:flex hx:items-center hx:ltr:right-3 hx:rtl:left-3">
                 {{- partial "utils/icon" (dict "name" "check" "attributes" "height=1em width=1em") -}}
               </span>

--- a/layouts/_partials/utils/hugo-compat/language-direction.html
+++ b/layouts/_partials/utils/hugo-compat/language-direction.html
@@ -1,0 +1,15 @@
+{{/*
+Returns the language direction using the supported Hugo API for the running version.
+
+Hugo v0.158.0 deprecated Language.LanguageDirection in favor of Language.Direction.
+Keep the fallback so Hextra can continue supporting Hugo >= 0.146.0.
+*/}}
+{{- $language := . -}}
+{{- $direction := "" -}}
+{{- if ge (hugo.Version) "0.158.0" -}}
+  {{- $direction = $language.Direction -}}
+{{- else -}}
+  {{- $direction = $language.LanguageDirection -}}
+{{- end -}}
+
+{{- return $direction -}}

--- a/layouts/_partials/utils/hugo-compat/language-label.html
+++ b/layouts/_partials/utils/hugo-compat/language-label.html
@@ -1,0 +1,15 @@
+{{/*
+Returns the language label using the supported Hugo API for the running version.
+
+Hugo v0.158.0 deprecated Language.LanguageName in favor of Language.Label.
+Keep the fallback so Hextra can continue supporting Hugo >= 0.146.0.
+*/}}
+{{- $language := . -}}
+{{- $label := "" -}}
+{{- if ge (hugo.Version) "0.158.0" -}}
+  {{- $label = $language.Label -}}
+{{- else -}}
+  {{- $label = $language.LanguageName -}}
+{{- end -}}
+
+{{- return $label -}}

--- a/layouts/_partials/utils/hugo-compat/language-locale.html
+++ b/layouts/_partials/utils/hugo-compat/language-locale.html
@@ -1,0 +1,15 @@
+{{/*
+Returns the language locale using the supported Hugo API for the running version.
+
+Hugo v0.158.0 deprecated Language.LanguageCode in favor of Language.Locale.
+Keep the fallback so Hextra can continue supporting Hugo >= 0.146.0.
+*/}}
+{{- $language := . -}}
+{{- $locale := "" -}}
+{{- if ge (hugo.Version) "0.158.0" -}}
+  {{- $locale = $language.Locale -}}
+{{- else -}}
+  {{- $locale = $language.LanguageCode -}}
+{{- end -}}
+
+{{- return $locale -}}

--- a/layouts/_partials/utils/hugo-compat/site-data.html
+++ b/layouts/_partials/utils/hugo-compat/site-data.html
@@ -1,0 +1,14 @@
+{{/*
+Returns site data using the supported Hugo API for the running version.
+
+Hugo v0.156.0 deprecated site.Data / .Site.Data in favor of hugo.Data.
+Keep the fallback so Hextra can continue supporting Hugo >= 0.146.0.
+*/}}
+{{- $siteData := dict -}}
+{{- if ge (hugo.Version) "0.156.0" -}}
+  {{- $siteData = hugo.Data -}}
+{{- else -}}
+  {{- $siteData = site.Data -}}
+{{- end -}}
+
+{{- return $siteData -}}

--- a/layouts/_partials/utils/hugo-compat/sites.html
+++ b/layouts/_partials/utils/hugo-compat/sites.html
@@ -1,0 +1,14 @@
+{{/*
+Returns all sites using the supported Hugo API for the running version.
+
+Hugo v0.156.0 deprecated site.Sites / page.Sites in favor of hugo.Sites.
+Keep the fallback so Hextra can continue supporting Hugo >= 0.146.0.
+*/}}
+{{- $sites := slice -}}
+{{- if ge (hugo.Version) "0.156.0" -}}
+  {{- $sites = hugo.Sites -}}
+{{- else -}}
+  {{- $sites = site.Sites -}}
+{{- end -}}
+
+{{- return $sites -}}

--- a/layouts/_partials/utils/icon.html
+++ b/layouts/_partials/utils/icon.html
@@ -1,5 +1,6 @@
-{{/* Render raw svg icon from .Site.Data */}}
-{{- $icon := index site.Data.icons .name -}}
+{{/* Render raw svg icon from site data */}}
+{{- $siteData := partial "utils/hugo-compat/site-data.html" . -}}
+{{- $icon := index $siteData.icons .name -}}
 
 {{- if not $icon -}}
   {{ errorf "icon %q not found" .name }}

--- a/layouts/_partials/utils/lang-link.html
+++ b/layouts/_partials/utils/lang-link.html
@@ -13,7 +13,7 @@
 {{ end }}
 
 {{ if not $link }}
-  {{ range where $page.Sites ".Language.Lang" $lang }}
+  {{ range where (partial "utils/hugo-compat/sites.html" .) ".Language.Lang" $lang }}
     {{ $link = .Home.RelPermalink }}
   {{ end }}
 {{ end }}

--- a/layouts/_shortcodes/icon.html
+++ b/layouts/_shortcodes/icon.html
@@ -13,7 +13,8 @@ or
 */ -}}
 
 {{- $name := .Get "name" | default (.Get 0) -}}
-{{- $icon := index site.Data.icons $name -}}
+{{- $siteData := partial "utils/hugo-compat/site-data.html" . -}}
+{{- $icon := index $siteData.icons $name -}}
 {{- $attributes := .Get "attributes" | default "height=1em"}}
 
 {{- if not $icon -}}

--- a/layouts/_shortcodes/term.html
+++ b/layouts/_shortcodes/term.html
@@ -14,9 +14,10 @@ or
 {{- $entry := .Get "entry" | default (.Get 0) -}}
 {{- $entryLower := lower $entry -}}
 {{- $match := dict -}}
+{{- $siteData := partial "utils/hugo-compat/site-data.html" . -}}
 
 <!-- Go over the term data file - data/<lang>/termbase.yaml -->
-{{- range (index .Site.Data .Site.Language.Lang "termbase") -}}
+{{- range (index $siteData .Site.Language.Lang "termbase") -}}
   {{- if or (eq (lower .abbr) $entryLower) (eq (lower .term) $entryLower) -}}
     {{- $match = . -}}
     {{- break -}}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" dir="{{ .Site.Language.LanguageDirection | default `ltr` }}">
+<html lang="{{ .Site.Language.Lang }}" dir="{{ partial "utils/hugo-compat/language-direction.html" .Site.Language | default `ltr` }}">
   {{- partial "head.html" . -}}
   <body>
     <a href="#content" class="hx:sr-only hx:focus-visible:not-sr-only hx:focus-visible:fixed hx:focus-visible:z-50 hx:focus-visible:top-2 hx:focus-visible:left-2 hx:focus-visible:bg-primary-500 hx:focus-visible:text-white hx:focus-visible:px-4 hx:focus-visible:py-2 hx:focus-visible:rounded-md hx:focus-visible:text-sm hx:focus-visible:font-medium">

--- a/layouts/glossary.html
+++ b/layouts/glossary.html
@@ -6,7 +6,8 @@
       <main id="content" class="hx:w-full hx:min-w-0 hextra-max-content-width hx:px-6 hx:pt-4 hx:md:px-12">
         {{ if .Title }}<h1 class="hx:text-center hx:mt-2 hx:text-4xl hx:font-bold hx:tracking-tight hx:text-slate-900 hx:dark:text-slate-100">{{ .Title }}</h1>{{ end }}
         <div class="content">
-          {{- with (index .Site.Data .Site.Language.Lang "termbase") -}}
+          {{- $siteData := partial "utils/hugo-compat/site-data.html" . -}}
+          {{- with (index $siteData .Site.Language.Lang "termbase") -}}
           <dl>
             {{- range sort . "term" -}}
             <dt>

--- a/layouts/list.rss.xml
+++ b/layouts/list.rss.xml
@@ -3,7 +3,7 @@
     <title>{{ .Site.Title }} – {{ .Title }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <generator>Hugo -- gohugo.io</generator>{{ with partial "utils/hugo-compat/language-locale.html" .Site.Language }}
     <language>{{.}}</language>{{end}}{{ with .Site.Params.Author.email }}
     <managingEditor>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.Author.email }}
     <webMaster>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}


### PR DESCRIPTION
## Summary
- Add a `layouts/_partials/utils/hugo-compat/` helper layer to bridge Hugo API changes while keeping the current minimum version.
- Route site data, site list, language label/locale/direction lookups through version-aware helpers.
- Update glossary, icon, RSS, language switcher, Giscus, and page wrapper templates to avoid deprecated Hugo calls.
- Add a docs note in the multilingual guide pointing to Hugo’s official language configuration docs.

## Testing
- `hugo --gc --minify --themesDir=../.. --source=docs --logLevel info`
- `git diff --check`
- Verified the docs build no longer reports the template deprecations for the updated APIs; remaining warnings are limited to `docs/hugo.yaml` config keys.