### PR TITLE
fix: resolve page-relative URLs in details shortcode

### DIFF
--- a/layouts/_shortcodes/details.html
+++ b/layouts/_shortcodes/details.html
@@ -15,6 +15,6 @@ A built-in component to display a collapsible content.
     <strong class="hx:text-lg">{{ $title | markdownify }}</strong>
   </summary>
   <div class="hx:p-2 hx:overflow-hidden">
-    {{ .InnerDeindent | markdownify }}
+    {{ .InnerDeindent | $.Page.RenderString (dict "display" "block") }}
   </div>
 </details>


### PR DESCRIPTION
Hello,

I noticed my images were not showing up inside details blocks, and needed an extra "../" in the path compared to normal markdown.

This should fix it and keep relative paths to the .md file itself.
Of course you may think of a better solution :)

Awesome theme, Thank you!
Muit