### PR TITLE
Added foldable alerts

### DIFF
--- a/layouts/_markup/render-blockquote-alert.html
+++ b/layouts/_markup/render-blockquote-alert.html
@@ -5,5 +5,6 @@
 {{- $content := .Text -}}
 {{- $alertType := .AlertType -}}
 {{- $alertTitle := .AlertTitle -}}
+{{- $alertSign := .AlertSign -}}
 
-{{- partial "components/github-style-alert.html" (dict "content" $content "alertType" $alertType "alertTitle" $alertTitle) -}}
+{{- partial "components/github-style-alert.html" (dict "content" $content "alertType" $alertType "alertTitle" $alertTitle "alertSign" $alertSign) -}}

--- a/layouts/_partials/components/github-style-alert.html
+++ b/layouts/_partials/components/github-style-alert.html
@@ -37,6 +37,23 @@
 {{- $style := or ($styles.Get $alertType) ($styles.Get "default") -}}
 {{- $title := or $alertTitle (or (i18n $alertType) (title $alertType)) -}}
 
+{{- /* Check if .alertSign exists to determine if it's foldable */}}
+{{- if .alertSign }}
+<details class="hx:overflow-x-auto hx:mt-6 hx:flex hx:flex-col hx:rounded-lg hx:border hx:py-4 hx:px-4 hx:border-gray-200 hx:contrast-more:border-current hx:contrast-more:dark:border-current hx:group {{ $style.style }}" {{ if eq .alertSign "+" }}open{{ end }}>
+  <summary class="hx:flex hx:cursor-pointer hx:items-center hx:font-medium hx:before:mr-1 hx:before:inline-block hx:before:transition-transform hx:before:content-[''] hx:dark:before:invert hx:rtl:before:rotate-180 hx:group-open:before:rotate-90">
+    {{- with $style.icon -}}
+      {{- partial "utils/icon.html" (dict "name" . "attributes" `height=16px class="hx:inline-block hx:align-middle hx:mr-2"`) -}}
+    {{- end -}}
+    {{- $title -}}
+  </summary>
+
+  <div class="hx:w-full hx:min-w-0 hx:leading-7">
+    <div class="hx:mt-6 hx:leading-7 hx:first:mt-0">
+      {{- $content -}}
+    </div>
+  </div>
+</details>
+{{- else }}
 <div class="hx:overflow-x-auto hx:mt-6 hx:flex hx:flex-col hx:rounded-lg hx:border hx:py-4 hx:px-4 hx:border-gray-200 hx:contrast-more:border-current hx:contrast-more:dark:border-current {{ $style.style }}">
   <p class="hx:flex hx:items-center hx:font-medium">
     {{- with $style.icon -}}
@@ -51,3 +68,4 @@
     </div>
   </div>
 </div>
+{{- end }}


### PR DESCRIPTION
Hello!

I noticed in Hextra you couldn't make foldable alerts using + and - symbols after an alert.
See:  https://gohugo.io/render-hooks/blockquotes/#extended-syntax

**NOTE**: I didn't manage to get the color of the arrow to be that of the alert, maybe you can help me with that?

Here is how it looks:
<img width="631" height="62" alt="260430191504_zen" src="https://github.com/user-attachments/assets/e91c5278-deb2-4ba5-a915-c0a3abd8e26d" />

<img width="635" height="85" alt="260430191519_zen" src="https://github.com/user-attachments/assets/1b10dee4-4f8b-4c81-915a-b62aded38c21" />
<br>
