### PR TITLE
fix(sidebar): fall back to content tree when mobile menu has no entries

### DIFF
--- a/layouts/_partials/sidebar.html
+++ b/layouts/_partials/sidebar.html
@@ -80,7 +80,7 @@
   {{- $useMainMenu := and (eq $level 0) $toc -}}
   {{- $mainMenuEntries := slice -}}
 
-  {{- $items := slice -}}
+  {{- $items := where (union .context.RegularPages .context.Sections) "Params.sidebar.exclude" "!=" true -}}
   {{- if $useMainMenu -}}
     {{- range $menuItem := site.Menus.main -}}
       {{- $menuType := $menuItem.Params.type | default "" -}}
@@ -156,18 +156,14 @@
         {{- $mainMenuEntries = $mainMenuEntries | append (dict "type" "url" "link" $link "title" $menuTitle) -}}
       {{- end -}}
     {{- end -}}
-  {{- else -}}
-    {{- $items = where (union .context.RegularPages .context.Sections) "Params.sidebar.exclude" "!=" true -}}
   {{- end -}}
 
-  {{- $hasItems := gt (len $items) 0 -}}
-  {{- if $useMainMenu -}}
-    {{- $hasItems = gt (len $mainMenuEntries) 0 -}}
-  {{- end -}}
+  {{- $useMainMenuEntries := and $useMainMenu (gt (len $mainMenuEntries) 0) -}}
+  {{- $hasItems := or (gt (len $items) 0) $useMainMenuEntries -}}
 
   {{- if $hasItems -}}
     {{- if eq $level 0 -}}
-      {{- if $useMainMenu -}}
+      {{- if $useMainMenuEntries -}}
         {{- /* Mixed list: page entries render trees; url entries render leaf links. */ -}}
         {{- range $entry := $mainMenuEntries -}}
           {{- if eq (index $entry "type") "page" -}}

--- a/tests/mobile-menu.spec.ts
+++ b/tests/mobile-menu.spec.ts
@@ -1,4 +1,14 @@
 import { test, expect } from "@playwright/test";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 
 test("clicking mobile hamburger does not focus the sidebar search input", async ({ page }) => {
   await page.setViewportSize({ width: 375, height: 812 });
@@ -47,4 +57,91 @@ test("mobile sidebar uses localized page titles for zh-cn docs navigation", asyn
   await expect(organizeFiles).toHaveText("文件组织");
   await expect(gettingStarted).not.toHaveText("Getting Started");
   await expect(guide).not.toHaveText("Guide");
+});
+
+test("mobile sidebar falls back to content tree when main menu has no eligible entries", async () => {
+  const siteDir = mkdtempSync(join(tmpdir(), "hextra-mobile-menu-"));
+  const contentDir = join(siteDir, "content");
+  const publishDir = join(siteDir, "public");
+
+  mkdirSync(join(contentDir, "docs"), { recursive: true });
+  mkdirSync(join(contentDir, "donate"), { recursive: true });
+  writeFileSync(
+    join(siteDir, "hugo.yaml"),
+    `title: Test
+theme: hextra
+menu:
+  main:
+    - name: Donate
+      pageRef: /donate
+      weight: 1
+    - name: Search
+      weight: 2
+      params:
+        type: search
+    - name: GitHub
+      weight: 3
+      url: "https://github.com/imfing/hextra"
+      params:
+        icon: github
+`,
+  );
+  writeFileSync(
+    join(contentDir, "_index.md"),
+    `---
+title: Home
+cascade:
+  type: docs
+---
+`,
+  );
+  writeFileSync(
+    join(contentDir, "docs", "_index.md"),
+    `---
+title: Docs
+---
+`,
+  );
+  writeFileSync(
+    join(contentDir, "docs", "getting-started.md"),
+    `---
+title: Getting Started
+---
+`,
+  );
+  writeFileSync(
+    join(contentDir, "donate", "index.md"),
+    `---
+title: Donate
+sidebar:
+  exclude: true
+---
+`,
+  );
+
+  try {
+    execFileSync(
+      "hugo",
+      [
+        "--source",
+        siteDir,
+        "--themesDir",
+        dirname(process.cwd()),
+        "--destination",
+        publishDir,
+      ],
+      { cwd: process.cwd(), stdio: "pipe" },
+    );
+
+    const html = readFileSync(join(publishDir, "index.html"), "utf8");
+    const mobileSidebar = html.match(
+      /<ul class="hx:flex hx:flex-col hx:gap-1 hx:md:hidden">([\s\S]*?)<\/ul>/,
+    )?.[1];
+
+    expect(mobileSidebar).toBeTruthy();
+    expect(mobileSidebar).toContain('href="/docs/"');
+    expect(mobileSidebar).toContain('href="/docs/getting-started/"');
+  } finally {
+    rmSync(siteDir, { recursive: true, force: true });
+  }
 });

--- a/tests/mobile-menu.spec.ts
+++ b/tests/mobile-menu.spec.ts
@@ -5,10 +5,11 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 
 test("clicking mobile hamburger does not focus the sidebar search input", async ({ page }) => {
   await page.setViewportSize({ width: 375, height: 812 });
@@ -59,13 +60,18 @@ test("mobile sidebar uses localized page titles for zh-cn docs navigation", asyn
   await expect(guide).not.toHaveText("Guide");
 });
 
-test("mobile sidebar falls back to content tree when main menu has no eligible entries", async () => {
+test("mobile sidebar falls back to content tree when main menu has no eligible entries", async ({
+  page,
+}) => {
   const siteDir = mkdtempSync(join(tmpdir(), "hextra-mobile-menu-"));
   const contentDir = join(siteDir, "content");
   const publishDir = join(siteDir, "public");
+  const themesDir = join(siteDir, "themes");
 
   mkdirSync(join(contentDir, "docs"), { recursive: true });
   mkdirSync(join(contentDir, "donate"), { recursive: true });
+  mkdirSync(themesDir);
+  symlinkSync(process.cwd(), join(themesDir, "hextra"), "dir");
   writeFileSync(
     join(siteDir, "hugo.yaml"),
     `title: Test
@@ -126,7 +132,7 @@ sidebar:
         "--source",
         siteDir,
         "--themesDir",
-        dirname(process.cwd()),
+        themesDir,
         "--destination",
         publishDir,
       ],
@@ -134,13 +140,17 @@ sidebar:
     );
 
     const html = readFileSync(join(publishDir, "index.html"), "utf8");
-    const mobileSidebar = html.match(
-      /<ul class="hx:flex hx:flex-col hx:gap-1 hx:md:hidden">([\s\S]*?)<\/ul>/,
-    )?.[1];
+    await page.setContent(html);
 
-    expect(mobileSidebar).toBeTruthy();
-    expect(mobileSidebar).toContain('href="/docs/"');
-    expect(mobileSidebar).toContain('href="/docs/getting-started/"');
+    const mobileSidebar = page
+      .locator("aside.hextra-sidebar-container ul")
+      .filter({ has: page.locator('a[href="/docs/"]') })
+      .first();
+
+    await expect(mobileSidebar.locator('a[href="/docs/"]')).toHaveText("Docs");
+    await expect(
+      mobileSidebar.locator('a[href="/docs/getting-started/"]'),
+    ).toHaveText("Getting Started");
   } finally {
     rmSync(siteDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Fixes #973.

Fixes a mobile sidebar regression where docs sites could render an empty mobile drawer when `menu.main` contained only navbar utility entries, icon-only links, or pages excluded from the sidebar.

The regression was introduced by #883 / commit `55659bb` (`fix(navbar): align mobile sidebar ordering and labels with menu.main`), which changed the mobile sidebar source from the root content tree to `menu.main`. For sites like MobiFlight, `menu.main` is not a docs navigation tree, so all entries were filtered or excluded and the mobile sidebar became empty.

This change keeps the `menu.main` behavior when eligible mobile menu entries exist, but falls back to the content tree when `menu.main` produces no sidebar-eligible entries.

## Testing

- `npm run build`
- `npm run test:mobile-menu`
- Verified MobiFlight docs render mobile sidebar content again when built against this local Hextra change.