### PR TITLE
feat(search): Drop HTML tags from search result

### DIFF
--- a/layouts/_partials/utils/extract-headings.html
+++ b/layouts/_partials/utils/extract-headings.html
@@ -21,7 +21,8 @@ The scratchpad must be initialized with empty slices before calling this functio
     {{- $.scratch.Add "endTags" (slice "") -}}
     {{- $.scratch.Add "ids" (slice "") -}}
   {{- else -}}
-    {{- $key := (printf "%s#%s" $heading.ID $heading.Title) -}}
+    {{- $headingTitle := $heading.Title | plainify | htmlUnescape | strings.TrimSpace -}}
+    {{- $key := (printf "%s#%s" $heading.ID $headingTitle) -}}
     {{- $.scratch.Add "keys" (slice $key) -}}
     {{- $marker := printf "<h%d data-hextra-search-id=\"%s\"" $heading.Level ($heading.ID | safeURL) -}}
     {{- $.scratch.Add "markers" (slice $marker) -}}

--- a/tests/search-fragments.spec.ts
+++ b/tests/search-fragments.spec.ts
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSyn
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-test("search fragments support inline markup in headings", () => {
+test("search fragments extract correctly for headings with inline markup", () => {
   const siteDir = mkdtempSync(join(tmpdir(), "hextra-search-fragments-"));
   const contentDir = join(siteDir, "content");
   const publishDir = join(siteDir, "public");
@@ -61,7 +61,7 @@ SECOND_DUPLICATE_BODY_TOKEN
     expect(fragments[""]).toBe("PREAMBLE_TOKEN");
     expect(fragments["plain-heading#Plain Heading"]).toBe("PLAIN_BODY_TOKEN");
     expect(fragments["link-heading#Link Heading"]).toBe("LINK_BODY_TOKEN");
-    expect(fragments["emphasized-code-1#<em>Emphasized</em> <code>Code</code> #1"]).toBe("FORMATTED_BODY_TOKEN");
+    expect(fragments["emphasized-code-1#Emphasized Code #1"]).toBe("FORMATTED_BODY_TOKEN");
     expect(fragments["duplicate#Duplicate"]).toBe("FIRST_DUPLICATE_BODY_TOKEN");
     expect(fragments["duplicate-1#Duplicate"]).toBe("SECOND_DUPLICATE_BODY_TOKEN");
   } finally {


### PR DESCRIPTION
Fixes #1019

As written in the issue, one alternative is to make this an opt-in if it's consider a breaking change or non sensible default. Since I suspect it isn't necessarily a deliberate feature to show the tags in the search result initially I opted to always drop them.

Let me know if you want me to put it behind config (default off) or just close out the PR (and issue) if this isn't wanted.