### PR TITLE
allow to specify katex options in config file

### DIFF
--- a/docs/content/docs/guide/latex.md
+++ b/docs/content/docs/guide/latex.md
@@ -127,6 +127,23 @@ params:
 
 It will load the KaTeX CSS file from `assets/css/katex.min.css` instead of downloading from CDN.
 
+##### Supply Options to `tomath` function
+
+Control the behaviour of the `transform.ToMath` function which handles the rendering.
+
+```yaml {filename="hugo.yaml"}
+params:
+  math:
+    katex:
+      options:
+        strict: "warn"
+        # Options from https://gohugo.io/functions/transform/tomath/
+
+```
+
+All options which are given to the `transform.ToMath` function can be used.
+See [https://gohugo.io/functions/transform/tomath/].
+
 #### MathJax
 
 Alternatively, you can use [MathJax][mathjax] to render math expressions:

--- a/layouts/_markup/render-passthrough.html
+++ b/layouts/_markup/render-passthrough.html
@@ -1,6 +1,7 @@
 {{- $engine := site.Params.math.engine | default "katex" -}}
 {{- if eq $engine "katex" -}}
   {{- $opts := dict "output" "htmlAndMathml" "displayMode" (eq .Type "block") }}
+  {{- $opts := merge site.Params.math.engine.katex.options $opts }}
   {{- with try (transform.ToMath .Inner $opts) }}
     {{- with .Err }}
       {{ errorf "Unable to render mathematical markup to HTML using the transform.ToMath function. The KaTeX display engine threw the following error: %s: see %s." . $.Position }}


### PR DESCRIPTION
- supply `transform.ToMath` with globally specified options which are defined in the main hugo.yaml (or similar) file
- extend documentation in `docs/guides/latex.md`