### PR TITLE
feat: add option to pass directory to site.Params.math.katex.assets

### DIFF
--- a/layouts/_partials/scripts/katex.html
+++ b/layouts/_partials/scripts/katex.html
@@ -73,19 +73,30 @@
   {{- end -}}
 {{- end -}}
 
-{{- /* Optionally publish files (fonts, css, js, etc.) from assets and emit tags for css/js with integrity and crossorigin */ -}}
+{{- /* Optionally publish files (fonts, css, js, etc.) or directories (ends with /) from assets and emit tags for css/js with integrity and crossorigin */ -}}
 {{- with site.Params.math.katex.assets -}}
   {{- range . -}}
-    {{- with resources.Get . -}}
-      {{- $name := .Name | lower -}}
-      {{- if strings.HasSuffix $name ".css" -}}
-        {{- $built := . | fingerprint "sha512" -}}
-        <link rel="stylesheet" href="{{ $built.RelPermalink }}" integrity="{{ $built.Data.Integrity }}" crossorigin="anonymous" />
-      {{- else if or (strings.HasSuffix $name ".js") (strings.HasSuffix $name ".mjs") -}}
-        {{- $built := . | fingerprint "sha512" -}}
-        <script src="{{ $built.RelPermalink }}" async integrity="{{ $built.Data.Integrity }}" crossorigin="anonymous"></script>
-      {{- else -}}
-        {{- .Publish -}}
+    {{- $files := "" -}}
+    {{- if strings.HasSuffix . "/" -}}
+      {{- $files = resources.Match (printf "%s**" .) -}}
+    {{- else if strings.Contains . "*" -}}
+      {{- $files = resources.Match . -}}
+    {{- else -}}
+      {{- $files = slice (resources.Get .) -}}
+    {{- end -}}
+
+    {{- range $files -}}
+      {{- if . -}}
+        {{- $name := .Name | lower -}}
+        {{- if strings.HasSuffix $name ".css" -}}
+          {{- $built := . | fingerprint "sha512" -}}
+          <link rel="stylesheet" href="{{ $built.RelPermalink }}" integrity="{{ $built.Data.Integrity }}" crossorigin="anonymous" />
+        {{- else if or (strings.HasSuffix $name ".js") (strings.HasSuffix $name ".mjs") -}}
+          {{- $built := . | fingerprint "sha512" -}}
+          <script src="{{ $built.RelPermalink }}" async integrity="{{ $built.Data.Integrity }}" crossorigin="anonymous"></script>
+        {{- else -}}
+          {{- .Publish -}}
+        {{- end -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}


### PR DESCRIPTION
# Problem
In `params.math.katex.assets`, you have to specify a whole list of files, which is inconvenient if there are many of them (such as fonts), because it bloats the `hugo.yaml` file

# Solution
Added the ability to specify a directory so that all files in it are included, without having to list every file individually (combined approaches also work)

## Before
```yaml
# hugo.yaml
params:
  math:
    engine: katex
    katex:
      css: “css/katex.min.css”
      assets:
        - css/fonts/KaTeX_AMS-Regular.ttf
        - css/fonts/KaTeX_AMS-Regular.woff
        - css/fonts/KaTeX_AMS-Regular.woff2
        - css/fonts/KaTeX_Caligraphic-Bold.ttf
        ...
```

## Now
```yaml
# hugo.yaml
params:
  math:
    engine: katex
    katex:
      css: “css/katex.min.css”
      assets:
        - css/fonts/
```